### PR TITLE
Revert "#265 Lint in Makefile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,4 @@ generate-swagger:
 	@rm docs/docs.go
 
 $(OBJS):
-	golangci-lint run ./...
 	go build -o build/$@ -ldflags='-X main.Version=${BRANCH}-${COMMIT}' ${EXTRAFLAGS} ${BASEPKG}/cmd/$@


### PR DESCRIPTION
Reverts allinbits/demeris-api-server#10
Need to revert this, as it breaks the docker file.
ref: https://github.com/allinbits/emeris-cns-server/pull/12#discussion_r761443669