### PR TITLE
bugfix(account): return `verified = false` on DenomTrace query fail

### DIFF
--- a/api/account/api.go
+++ b/api/account/api.go
@@ -90,42 +90,59 @@ func GetBalancesByAddress(c *gin.Context) {
 	// perhaps we can remove this since there will be another endpoint specifically for fee tokens
 
 	for _, b := range balances {
-		balance := balance{
-			Address: b.Address,
-			Amount:  b.Amount,
-			OnChain: b.ChainName,
-		}
-
-		verified := vd[b.Denom]
-		baseDenom := b.Denom
-
-		if b.Denom[:4] == "ibc/" {
-			// is ibc token
-			balance.Ibc = ibcInfo{
-				Hash: b.Denom[4:],
-			}
-
-			// if err is nil, the ibc denom has a denom trace associated with it
-			// so we return it, along with its verified status as well as the complete ibc
-			// path
-
-			// otherwise, since we don't touch `verified` and `baseDenom` variables, we stick to the
-			// original `ibc/...` denom, which will be unverified by default
-			denomTrace, err := d.Database.DenomTrace(b.ChainName, b.Denom[4:])
-			if err == nil {
-				balance.Ibc.Path = denomTrace.Path
-				baseDenom = denomTrace.BaseDenom
-				verified = vd[denomTrace.BaseDenom]
-			}
-		}
-
-		balance.Verified = verified
-		balance.BaseDenom = baseDenom
-
-		res.Balances = append(res.Balances, balance)
+		res.Balances = append(res.Balances, balanceRespForBalance(
+			b,
+			vd,
+			d.Database.DenomTrace,
+		))
 	}
 
 	c.JSON(http.StatusOK, res)
+}
+
+// What lies ahead is a refactoring operation to ease testing of the algorithm implemented
+// to determine whether a given IBC balance is verified or not.
+// Since at the time of this commit there isn't a well-formed testing framework for
+// api-server, we refactored the algo out, and provided a database querying function type.
+// This way we can easily implement table testing for this sensible component, and provide
+// fixes to it in a time-sensitive manner.
+// This will most probably go away as soon as we have proper testing in place.
+type denomTraceFunc func(string, string) (tracelistener.IBCDenomTraceRow, error)
+
+func balanceRespForBalance(rawBalance tracelistener.BalanceRow, vd map[string]bool, dt denomTraceFunc) balance {
+	balance := balance{
+		Address: rawBalance.Address,
+		Amount:  rawBalance.Amount,
+		OnChain: rawBalance.ChainName,
+	}
+
+	verified := vd[rawBalance.Denom]
+	baseDenom := rawBalance.Denom
+
+	if rawBalance.Denom[:4] == "ibc/" {
+		// is ibc token
+		balance.Ibc = ibcInfo{
+			Hash: rawBalance.Denom[4:],
+		}
+
+		// if err is nil, the ibc denom has a denom trace associated with it
+		// so we return it, along with its verified status as well as the complete ibc
+		// path
+
+		// otherwise, since we don't touch `verified` and `baseDenom` variables, we stick to the
+		// original `ibc/...` denom, which will be unverified by default
+		denomTrace, err := dt(rawBalance.ChainName, rawBalance.Denom[4:])
+		if err == nil {
+			balance.Ibc.Path = denomTrace.Path
+			baseDenom = denomTrace.BaseDenom
+			verified = vd[denomTrace.BaseDenom]
+		}
+	}
+
+	balance.Verified = verified
+	balance.BaseDenom = baseDenom
+
+	return balance
 }
 
 func verifiedDenomsMap(d *database.Database) (map[string]bool, error) {

--- a/api/account/api_test.go
+++ b/api/account/api_test.go
@@ -1,0 +1,150 @@
+package account
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/allinbits/demeris-backend-models/tracelistener"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_balanceRespForBalance(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawBalance tracelistener.BalanceRow
+		vd         map[string]bool
+		dt         denomTraceFunc
+		want       balance
+	}{
+		{
+			"verified IBC balance returns verified balance",
+			tracelistener.BalanceRow{
+				Address: "address",
+				Amount:  "42",
+				Denom:   "ibc/hash",
+			},
+			map[string]bool{
+				"uatom": true,
+			},
+			func(_, hash string) (tracelistener.IBCDenomTraceRow, error) {
+				return tracelistener.IBCDenomTraceRow{
+					Path:      "path",
+					BaseDenom: "uatom",
+					Hash:      "hash",
+				}, nil
+			},
+			balance{
+				Address:   "address",
+				BaseDenom: "uatom",
+				Verified:  true,
+				Amount:    "42",
+				OnChain:   "",
+				Ibc: ibcInfo{
+					Path: "path",
+					Hash: "hash",
+				},
+			},
+		},
+		{
+			"non-verified IBC balance returns non-verified balance",
+			tracelistener.BalanceRow{
+				Address: "address",
+				Amount:  "42",
+				Denom:   "ibc/hash",
+			},
+			map[string]bool{
+				"uatom": false,
+			},
+			func(_, hash string) (tracelistener.IBCDenomTraceRow, error) {
+				return tracelistener.IBCDenomTraceRow{
+					Path:      "path",
+					BaseDenom: "uatom",
+					Hash:      "hash",
+				}, nil
+			},
+			balance{
+				Address:   "address",
+				BaseDenom: "uatom",
+				Verified:  false,
+				Amount:    "42",
+				OnChain:   "",
+				Ibc: ibcInfo{
+					Path: "path",
+					Hash: "hash",
+				},
+			},
+		},
+		{
+			"error on denomtrace function returns unverified balance",
+			tracelistener.BalanceRow{
+				Address: "address",
+				Amount:  "42",
+				Denom:   "ibc/hash",
+			},
+			map[string]bool{
+				"uatom": true,
+			},
+			func(_, hash string) (tracelistener.IBCDenomTraceRow, error) {
+				return tracelistener.IBCDenomTraceRow{}, fmt.Errorf("error")
+			},
+			balance{
+				Address:   "address",
+				BaseDenom: "ibc/hash",
+				Verified:  false,
+				Amount:    "42",
+				OnChain:   "",
+				Ibc: ibcInfo{
+					Hash: "hash",
+				},
+			},
+		},
+		{
+			"verified non-ibc token returns verified balance",
+			tracelistener.BalanceRow{
+				Address: "address",
+				Amount:  "42",
+				Denom:   "denom",
+			},
+			map[string]bool{
+				"denom": true,
+			},
+			func(_, hash string) (tracelistener.IBCDenomTraceRow, error) {
+				return tracelistener.IBCDenomTraceRow{}, nil
+			},
+			balance{
+				Address:   "address",
+				BaseDenom: "denom",
+				Verified:  true,
+				Amount:    "42",
+			},
+		},
+		{
+			"non-verified non-ibc token returns non-verified balance",
+			tracelistener.BalanceRow{
+				Address: "address",
+				Amount:  "42",
+				Denom:   "denom",
+			},
+			map[string]bool{
+				"denom": false,
+			},
+			func(_, hash string) (tracelistener.IBCDenomTraceRow, error) {
+				return tracelistener.IBCDenomTraceRow{}, nil
+			},
+			balance{
+				Address:   "address",
+				BaseDenom: "denom",
+				Verified:  false,
+				Amount:    "42",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t,
+				tt.want,
+				balanceRespForBalance(tt.rawBalance, tt.vd, tt.dt),
+			)
+		})
+	}
+}


### PR DESCRIPTION
Before this PR a `/balance` query which contained a unverified denomination trace would return error.

Instead, we adopt the same approach we used in `/verify_trace`, and return `verified = false` on such occasions, letting the query still return `200 OK`, along with the original IBC denom.

This PR will be cherry-picked back to `sahith/fix-prodn` for a speedy deployment on production, since `main` here already implements `sdk-service` integration.

Please, double-check everything here because I feel awful today and might've introduced weird bugs :^)

Closes #27.