### PR TITLE
fix(api): query all possible ibc seq numbers instead of hardcoding the JSON path

### DIFF
--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -18,7 +18,7 @@ import (
 // can be updated to more readable format after typed events are introduced in sdk
 const (
 	// packetSequencePath may need updates if ibc-go/transfer events change
-	packetSequencePath = "tx_response.logs.0.events.2.attributes.3.value"
+	packetSequencePath = `tx_response.logs.#.events.#(type=="send_packet").attributes.#(key=="packet_sequence").value`
 	// txPath may need updates if tendermint response changes
 	txPath  = "result.txs.0.hash"
 	timeout = 10 * time.Second
@@ -134,8 +134,36 @@ func GetDestTx(c *gin.Context) {
 		return
 	}
 
-	r := gjson.GetBytes(sdkRes, packetSequencePath)
-	url := fmt.Sprintf("http://%s:26657/tx_search?query=\"recv_packet.packet_sequence=%s\"", destChainInfo.ChainName, r.String())
+	// This query always returns an array of sequence numbers.
+	// Emeris-generated IBC transfers are always sent out alone, meaning that
+	// there are no more than 1 IBC transfer per tx.
+	// This code is ready to be adapted to support multiple IBC transfer/transaction, but
+	// for now we just get the first seq number found and roll with it.
+	r := gjson.GetBytes(sdkRes, packetSequencePath).Array()
+	if len(r) == 0 {
+		e := deps.NewError(
+			"chains",
+			fmt.Errorf("provided transaction is not ibc transfer"),
+			http.StatusBadRequest,
+		)
+
+		d.WriteError(c, e,
+			"provided transaction is not ibc transfer",
+			"id",
+			e.ID,
+			"txHash",
+			txHash,
+			"src srcChainInfo name",
+			srcChain,
+			"error",
+			err,
+		)
+
+		return
+	}
+
+	seqNum := r[0].String()
+	url := fmt.Sprintf("http://%s:26657/tx_search?query=\"recv_packet.packet_sequence=%s\"", destChainInfo.ChainName, seqNum)
 
 	httpClient := &http.Client{
 		Timeout: timeout,
@@ -143,10 +171,10 @@ func GetDestTx(c *gin.Context) {
 
 	// we're validating inputs and hence gosec-G107 can be ignored
 	resp, err := httpClient.Get(url) // nolint: gosec
-	if err != nil {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		e := deps.NewError(
 			"chains",
-			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", r.String(), destChain),
+			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
 		)
 
@@ -160,6 +188,8 @@ func GetDestTx(c *gin.Context) {
 			destChain,
 			"error",
 			err,
+			"status_code",
+			resp.Status,
 		)
 
 		return
@@ -170,7 +200,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := deps.NewError(
 			"chains",
-			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", r.String(), destChain),
+			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
 		)
 
@@ -189,9 +219,9 @@ func GetDestTx(c *gin.Context) {
 		return
 	}
 
-	r = gjson.GetBytes(bz, txPath)
+	otherSideTxHash := gjson.GetBytes(bz, txPath)
 	c.JSON(http.StatusOK, DestTxResponse{
 		DestChain: destChain,
-		TxHash:    r.String(),
+		TxHash:    otherSideTxHash.String(),
 	})
 }

--- a/api/tx/ibc_test.go
+++ b/api/tx/ibc_test.go
@@ -1,0 +1,106 @@
+package tx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getIBCSeqFromTx(t *testing.T) {
+	// This test assumes tx_response.logs.events is always present,
+	// because Tendermint events are formatted this way.
+	tests := []struct {
+		name    string
+		payload string
+		want    []string
+	}{
+		{
+			"ibc send payload with a single transfer",
+			`{
+				"tx_response":{
+				   "logs":[
+					  {
+						 "events":[
+							{
+							   "type":"send_packet",
+							   "attributes":[
+								  {
+									 "key":"packet_sequence",
+									 "value":"42"
+								  }
+							   ]
+							}
+						 ]
+					  }
+				   ]
+				}
+			 }`,
+			[]string{"42"},
+		},
+		{
+			"ibc send payload with multiple transfer",
+			`{
+				"tx_response":{
+				   "logs":[
+					  {
+						 "events":[
+							{
+							   "type":"send_packet",
+							   "attributes":[
+								  {
+									 "key":"packet_sequence",
+									 "value":"42"
+								  }
+							   ]
+							}
+						 ]
+					  },
+					  {
+						"events":[
+						   {
+							  "type":"send_packet",
+							  "attributes":[
+								 {
+									"key":"packet_sequence",
+									"value":"44"
+								 }
+							  ]
+						   }
+						]
+					 }
+				   ]
+				}
+			 }`,
+			[]string{"42", "44"},
+		},
+		{
+			"transaction with no IBC-related tx's",
+			`{
+				"tx_response":{
+				   "logs":[
+					  {
+						 "events":[
+							{
+							   "type":"fake_event",
+							   "attributes":[
+								  {
+									 "key":"packet_sequence",
+									 "value":"42"
+								  }
+							   ]
+							}
+						 ]
+					  }
+				   ]
+				}
+			 }`,
+			[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := getIBCSeqFromTx([]byte(tt.payload))
+			require.ElementsMatch(t, res, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
See comment on line 137 on this PR's changes for more info.

This should address https://allinbits.slack.com/archives/C02JXQVAP3K/p1643377184110309