### PR TITLE
fix(sdkservice): add missing delegator reward endpoint client entry

### DIFF
--- a/sdkservice/sdkservice.go
+++ b/sdkservice/sdkservice.go
@@ -38,6 +38,7 @@ func Client(sdkVersion string) (sdkutilities.Client, error) {
 		MintParamsEndpoint:          client.MintParams(),
 		MintAnnualProvisionEndpoint: client.MintAnnualProvision(),
 		EstimateFeesEndpoint:        client.EstimateFees(),
+		DelegatorRewardsEndpoint:    client.DelegatorRewards(),
 	}
 
 	return cc, nil


### PR DESCRIPTION
This commit adds a missing endpoint in the sdk service client
configuration, fixing a panic generated by this kind of calls:
`https://allinbits.slack.com/archives/C02JXQVAP3K/p1644834819960559`.