### PR TITLE
build: speed up Docker builds on code changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN git config --global url."https://git:${GIT_TOKEN}@github.com".insteadOf "htt
 
 WORKDIR /app
 COPY go.mod go.sum* ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOPROXY=direct make
+RUN --mount=type=cache,target=/go/pkg/mod \
+	--mount=type=cache,target=/root/.cache/go-build \
+	CGO_ENABLED=0 GOPROXY=direct make
 
 FROM alpine:latest
 


### PR DESCRIPTION
Using Buildkit caches helps in mantaining state for command being executed.

In this commit we cache the packages download by go mod and the compilation output (that can even be shared reused by other services, by changing their Dockerfile in a similar way).

docs: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache