### PR TITLE
Never return 400 in denom/verify_trace

### DIFF
--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -468,7 +468,7 @@ func VerifyTrace(c *gin.Context) {
 
 				c.JSON(http.StatusOK, res)
 			} else {
-				cause := fmt.Sprintf("invalid number of query responses")
+				cause := "invalid number of query responses"
 
 				d.LogError(
 					"invalid number of query responses",
@@ -497,7 +497,7 @@ func VerifyTrace(c *gin.Context) {
 		primaryChannelInfo, err := d.Database.PrimaryChannelCounterparty(chainName, nextChain)
 
 		if err != nil {
-			cause := fmt.Sprintf("invalid number of query responses")
+			cause := "invalid number of query responses"
 
 			d.LogError(
 				cause,


### PR DESCRIPTION
#66 

FE will only handle `200` response codes for `denom/verify_trace` otherwise the whole app breaks, so we will always return `200` in `denom/verify_trace`

- Logs error + includes cause of failure in response
- Never return error struct
- Unit tests