### PR TITLE
ci: fix golang-ci lint after major upgrade

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
       - name: Configure git for private modules
         env:
           GIT_TOKEN: ${{ secrets.TENDERBOT_GIT_TOKEN }}
@@ -25,6 +31,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.43
+          version: v1.44
           args: --timeout 10m
           github-token: ${{ secrets.TENDERBOT_GIT_TOKEN }}


### PR DESCRIPTION
v3 of golang-ci lint action now explicitly requires a setup-go step before running.

See breaking changes: https://github.com/golangci/golangci-lint-action#compatibility