### PR TITLE
fix(router): avoid settings logger from request due to race conditions

### DIFF
--- a/api/router/deps/deps.go
+++ b/api/router/deps/deps.go
@@ -34,10 +34,18 @@ func GetDeps(c *gin.Context) *Deps {
 		panic(fmt.Sprintf("deps not of the expected type, found %T", deps))
 	}
 
+	// override logger with the one from the gin.context
+	logger, err := logging.GetLoggerFromContext(c)
+	if err == nil {
+		deps.Logger = logger
+	} else {
+		deps.Logger.Warnw("couldn't get logger from context, using fallback", "error", err)
+	}
+
 	return deps
 }
 
-// WriteError lgos and return client-facing errors
+// WriteError logs and return client-facing errors
 func (d *Deps) WriteError(c *gin.Context, err Error, logMessage string, keyAndValues ...interface{}) {
 
 	// setting error id

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -75,7 +75,6 @@ func New(
 	if debug {
 		engine.Use(logging.LogRequest(l.Desugar()))
 	}
-	engine.Use(r.setLoggerFromContext)
 	engine.Use(r.catchPanicsFunc)
 	engine.Use(r.decorateCtxWithDeps)
 	engine.Use(r.handleErrors)
@@ -89,16 +88,6 @@ func New(
 
 func (r *Router) Serve(address string) error {
 	return r.g.Run(address)
-}
-
-func (r *Router) setLoggerFromContext(c *gin.Context) {
-	l, err := logging.GetLoggerFromContext(c)
-	if err != nil && r.l == nil {
-		panic("cant get logger from context")
-	}
-	if l != nil {
-		r.l = l
-	}
 }
 
 func (r *Router) catchPanicsFunc(c *gin.Context) {

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -99,7 +99,8 @@ func (r *Router) catchPanicsFunc(c *gin.Context) {
 				errors.New("internal server error"),
 				http.StatusInternalServerError)
 
-			r.l.Errorw(
+			logger := logging.AddCorrelationIDToLogger(c, r.l)
+			logger.Errorw(
 				"panic handler triggered while handling call",
 				"endpoint", c.Request.RequestURI,
 				"error", fmt.Sprint(rval),

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.18.0
 	github.com/allinbits/demeris-backend-models v1.0.0
 	github.com/allinbits/emeris-cns-server v0.0.0-20211201093144-fa626186dded
-	github.com/allinbits/emeris-utils v1.1.1
+	github.com/allinbits/emeris-utils v1.1.2
 	github.com/allinbits/sdk-service-meta v0.0.0-20220225122854-eb00092170cc
 	github.com/allinbits/starport-operator v0.0.1-alpha.45
 	github.com/cockroachdb/cockroach-go/v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/allinbits/demeris-backend-models v1.0.0 h1:USjPbAeHpaqO1Gg1GrseQif33S
 github.com/allinbits/demeris-backend-models v1.0.0/go.mod h1:P/PDgyB6Y/GcBcODjzHDfAT+WtDl86Qqq/LIbwHJAPI=
 github.com/allinbits/emeris-cns-server v0.0.0-20211201093144-fa626186dded h1:AD2UB10Bx7QgStLnJ6Jp1XQD2Y2u9Js0TMCJIhd61n8=
 github.com/allinbits/emeris-cns-server v0.0.0-20211201093144-fa626186dded/go.mod h1:FuP1e/sGgjXI/pJ0ipHmEWLHHQWMPwnT8rDFz2WKKUE=
-github.com/allinbits/emeris-utils v1.1.1 h1:x9oEPATvNvRkMVVoewLXlo+5rULpiEygvjH7MBwCv2c=
-github.com/allinbits/emeris-utils v1.1.1/go.mod h1:tMkUvBItgKYJZJUx8zpE9QWm+lqUb4MvT3fKohYOoHI=
+github.com/allinbits/emeris-utils v1.1.2 h1:18W+W3cF6rs34BqsYxfV/XHBBSaTo7Sh4zcGaDXpQXU=
+github.com/allinbits/emeris-utils v1.1.2/go.mod h1:tMkUvBItgKYJZJUx8zpE9QWm+lqUb4MvT3fKohYOoHI=
 github.com/allinbits/sdk-service-meta v0.0.0-20220225122854-eb00092170cc h1:RYkjiawhVW5kyGedO87fhoJ/B+mPKz3UbMWyCtfoJHU=
 github.com/allinbits/sdk-service-meta v0.0.0-20220225122854-eb00092170cc/go.mod h1:1qjnoOm6sxbMQp2uIMi2EaVIjAazPyom5HNUlGPZdAw=
 github.com/allinbits/starport-operator v0.0.1-alpha.26/go.mod h1:rhYpjy5c3QXjSS0SGxeDU/vVuxwLFeni1MJbpBTKXqo=


### PR DESCRIPTION
This fixes failing code_cov tests due to a concurrency problem that I did point out here: https://github.com/allinbits/demeris-api-server/pull/20#discussion_r804597994.