### PR TITLE
feat: add env variable to choose k8s config

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	DatabaseConnectionURL string `validate:"required"`
 	ListenAddr            string `validate:"required"`
 	RedisAddr             string `validate:"required"`
+	KubernetesConfigMode  string
 	KubernetesNamespace   string `validate:"required"`
 	Debug                 bool
 }

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -57,18 +57,26 @@ func main() {
 		l.Panicw("unable to start redis client", "error", err)
 	}
 
-	kubeClient, err := k8s.NewInCluster()
+	var k8sCfg *rest.Config
+	if cfg.KubernetesConfigMode == "kubectl" {
+		k8sCfg, err = k8s.KubectlConfig()
+		if err != nil {
+			l.Panicw("cannot get kubernetes config using kubectl", "error", err)
+		}
+	} else {
+		k8sCfg, err = k8s.InClusterConfig()
+		if err != nil {
+			l.Panicw("cannot get kubernetes config. Are you running this service inside a pod?", "error", err)
+		}
+	}
+
+	kubeClient, err := k8s.NewClient(k8sCfg)
 	if err != nil {
-		l.Panicw("cannot initialize k8s", "error", err)
+		l.Panicw("cannot initialize kubernetes client", "error", err)
 	}
 
 	l.Infow("setup relayers informer", "namespace", cfg.KubernetesNamespace)
-	infConfig, err := rest.InClusterConfig()
-	if err != nil {
-		l.Panicw("k8s server panic", "error", err)
-	}
-
-	informer, err := k8s.GetInformer(infConfig, cfg.KubernetesNamespace, "relayers")
+	informer, err := k8s.GetInformer(k8sCfg, cfg.KubernetesNamespace, "relayers")
 	if err != nil {
 		l.Panicw("k8s server panic", "error", err)
 	}


### PR DESCRIPTION
Using DEMERIS-API_KUBERNETESCONFIGMODE=kubectl env will make api-server init k8s clients using the current context of kubectl.

If not set, api-server is expected to be running inside a pod (old behaviour).

Requires changes from https://github.com/allinbits/emeris-utils/pull/38.