### PR TITLE
fix(stringcache): use correct go-redis method to get string value

### DIFF
--- a/lib/stringcache/storebackend.go
+++ b/lib/stringcache/storebackend.go
@@ -27,7 +27,7 @@ func (s *StoreBackend) Get(ctx context.Context, key string) (string, error) {
 		return "", fmt.Errorf("reading store: %w", err)
 	}
 
-	return cmd.String(), nil
+	return cmd.Val(), nil
 }
 
 func (s *StoreBackend) Set(ctx context.Context, key, value string, expiration time.Duration) error {

--- a/lib/stringcache/storebackend_test.go
+++ b/lib/stringcache/storebackend_test.go
@@ -1,0 +1,83 @@
+package stringcache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/emerishq/emeris-utils/store"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// NewStore returns an initialized test *Store connected to a miniredis instance.
+// The miniredis instance is also returned for convenience and further customizing the test environment.
+func NewStore(t *testing.T) (*store.Store, *miniredis.Miniredis) {
+	s := miniredis.RunT(t)
+	storeClient, err := store.NewClient(s.Addr())
+	if err != nil {
+		t.Fatalf("creating a new Store: %v", err)
+	}
+	return storeClient, s
+}
+
+func TestStoreBackend_SetNewKey(t *testing.T) {
+	assert := assert.New(t)
+	s, _ := NewStore(t)
+
+	back := NewStoreBackend(s)
+	err := back.Set(context.Background(), "key", "value", 10*time.Minute)
+	assert.NoError(err)
+}
+
+func TestStoreBackend_ReplaceKey(t *testing.T) {
+	assert := assert.New(t)
+	s, miniredis := NewStore(t)
+	_ = miniredis.Set("key", "something")
+
+	back := NewStoreBackend(s)
+	err := back.Set(context.Background(), "key", "value", 10*time.Minute)
+
+	assert.NoError(err)
+
+	val, _ := miniredis.Get("key")
+	assert.Equal("value", val)
+}
+
+func TestStoreBackend_GetKey(t *testing.T) {
+	assert := assert.New(t)
+	s, miniredis := NewStore(t)
+	_ = miniredis.Set("key", "something")
+
+	back := NewStoreBackend(s)
+	res, err := back.Get(context.Background(), "key")
+
+	assert.NoError(err)
+	assert.Equal("something", res)
+}
+
+func TestStoreBackend_GetUnsetKey(t *testing.T) {
+	assert := assert.New(t)
+	s, _ := NewStore(t)
+
+	back := NewStoreBackend(s)
+	_, err := back.Get(context.Background(), "key")
+
+	assert.ErrorIs(ErrCacheMiss, err)
+}
+
+func TestStoreBackend_GetAfterExpiration(t *testing.T) {
+	assert := assert.New(t)
+	s, miniredis := NewStore(t)
+
+	back := NewStoreBackend(s)
+	err := back.Set(context.Background(), "key", "value", 60*time.Second)
+	assert.NoError(err)
+
+	miniredis.FastForward(10 * time.Minute)
+
+	res, err := back.Get(context.Background(), "key")
+	assert.ErrorIsf(ErrCacheMiss, err, "expected cache miss, actual cache value was: %s", res)
+}

--- a/lib/stringcache/storebackend_test.go
+++ b/lib/stringcache/storebackend_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // NewStore returns an initialized test *Store connected to a miniredis instance.
@@ -24,60 +24,60 @@ func NewStore(t *testing.T) (*store.Store, *miniredis.Miniredis) {
 }
 
 func TestStoreBackend_SetNewKey(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	s, _ := NewStore(t)
 
 	back := NewStoreBackend(s)
 	err := back.Set(context.Background(), "key", "value", 10*time.Minute)
-	assert.NoError(err)
+	require.NoError(err)
 }
 
 func TestStoreBackend_ReplaceKey(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	s, miniredis := NewStore(t)
 	_ = miniredis.Set("key", "something")
 
 	back := NewStoreBackend(s)
 	err := back.Set(context.Background(), "key", "value", 10*time.Minute)
 
-	assert.NoError(err)
+	require.NoError(err)
 
 	val, _ := miniredis.Get("key")
-	assert.Equal("value", val)
+	require.Equal("value", val)
 }
 
 func TestStoreBackend_GetKey(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	s, miniredis := NewStore(t)
 	_ = miniredis.Set("key", "something")
 
 	back := NewStoreBackend(s)
 	res, err := back.Get(context.Background(), "key")
 
-	assert.NoError(err)
-	assert.Equal("something", res)
+	require.NoError(err)
+	require.Equal("something", res)
 }
 
 func TestStoreBackend_GetUnsetKey(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	s, _ := NewStore(t)
 
 	back := NewStoreBackend(s)
 	_, err := back.Get(context.Background(), "key")
 
-	assert.ErrorIs(ErrCacheMiss, err)
+	require.ErrorIs(ErrCacheMiss, err)
 }
 
 func TestStoreBackend_GetAfterExpiration(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	s, miniredis := NewStore(t)
 
 	back := NewStoreBackend(s)
 	err := back.Set(context.Background(), "key", "value", 60*time.Second)
-	assert.NoError(err)
+	require.NoError(err)
 
 	miniredis.FastForward(10 * time.Minute)
 
 	res, err := back.Get(context.Background(), "key")
-	assert.ErrorIsf(ErrCacheMiss, err, "expected cache miss, actual cache value was: %s", res)
+	require.ErrorIsf(ErrCacheMiss, err, "expected cache miss, actual cache value was: %s", res)
 }


### PR DESCRIPTION
Apparently I was using the wrong method so instead of returning

```
https://s3.amazonaws.com/keybase_processed_uploads/a3c1904616e3b1d6177a0b3770af3405_360_360.jpg
```

it is returning the full redis command:

```
get api-server/validator-avatars/C5B260EC48CF27CD: https://s3.amazonaws.com/keybase_processed_uploads/a3c1904616e3b1d6177a0b3770af3405_360_360.jpg
```

sorry 😓  I did manual test my previous pr but probably didn't pay enough attention?