### PR TITLE
refactor: clean up errors code

### DIFF
--- a/api/account/api.go
+++ b/api/account/api.go
@@ -57,8 +57,6 @@ func GetBalancesByAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query database balance for address",
-			"id",
-			e.ID,
 			"address",
 			address,
 			"error",
@@ -77,8 +75,6 @@ func GetBalancesByAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query database verified denoms",
-			"id",
-			e.ID,
 			"address",
 			address,
 			"error",
@@ -190,8 +186,6 @@ func GetDelegationsByAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query database delegations for addresses",
-			"id",
-			e.ID,
 			"address",
 			address,
 			"error",
@@ -240,8 +234,6 @@ func GetUnbondingDelegationsByAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query database unbonding delegations for addresses",
-			"id",
-			e.ID,
 			"address",
 			address,
 			"error",
@@ -293,8 +285,6 @@ func GetDelegatorRewards(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -314,8 +304,6 @@ func GetDelegatorRewards(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -340,8 +328,6 @@ func GetDelegatorRewards(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve delegator rewards from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -416,8 +402,6 @@ func GetNumbersByAddress(c *gin.Context) {
 
 			d.WriteError(c, e,
 				"cannot query database auth for addresses",
-				"id",
-				e.ID,
 				"address",
 				address,
 				"error",
@@ -437,8 +421,6 @@ func GetNumbersByAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query nodes auth for addresses",
-			"id",
-			e.ID,
 			"address",
 			address,
 			"error",

--- a/api/account/api.go
+++ b/api/account/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/emerishq/demeris-api-server/api/apiutils"
 	"github.com/emerishq/demeris-api-server/api/database"
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/demeris-api-server/sdkservice"
 	"github.com/emerishq/demeris-backend-models/cns"
 	"github.com/emerishq/demeris-backend-models/tracelistener"
@@ -48,7 +49,7 @@ func GetBalancesByAddress(c *gin.Context) {
 	balances, err := d.Database.Balances(address)
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"account",
 			fmt.Errorf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
@@ -68,7 +69,7 @@ func GetBalancesByAddress(c *gin.Context) {
 
 	vd, err := verifiedDenomsMap(d.Database)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"account",
 			fmt.Errorf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
@@ -181,7 +182,7 @@ func GetDelegationsByAddress(c *gin.Context) {
 	dl, err := d.Database.Delegations(address)
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"delegations",
 			fmt.Errorf("cannot retrieve delegations for address %v", address),
 			http.StatusBadRequest,
@@ -231,7 +232,7 @@ func GetUnbondingDelegationsByAddress(c *gin.Context) {
 	unbondings, err := d.Database.UnbondingDelegations(address)
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"unbonding delegations",
 			fmt.Errorf("cannot retrieve unbonding delegations for address %v", address),
 			http.StatusBadRequest,
@@ -284,7 +285,7 @@ func GetDelegatorRewards(c *gin.Context) {
 
 	chain, err := d.Database.Chain(chainName)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
@@ -305,7 +306,7 @@ func GetDelegatorRewards(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
@@ -331,7 +332,7 @@ func GetDelegatorRewards(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve delegator rewards from sdk-service"),
 			http.StatusInternalServerError,
@@ -407,7 +408,7 @@ func GetNumbersByAddress(c *gin.Context) {
 		dl, err := d.Database.Numbers(address)
 
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"numbers",
 				fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
 				http.StatusBadRequest,
@@ -428,7 +429,7 @@ func GetNumbersByAddress(c *gin.Context) {
 
 	resp, err := fetchNumbers(dd, address)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"numbers",
 			fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusInternalServerError,
@@ -459,7 +460,7 @@ func GetUserTickets(c *gin.Context) {
 
 	tickets, err := d.Store.GetUserTickets(address)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"tickets",
 			fmt.Errorf("cannot retrieve tickets for address %v", address),
 			http.StatusBadRequest,

--- a/api/block/api.go
+++ b/api/block/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/emerishq/emeris-utils/store"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -33,7 +34,7 @@ func GetBlock(c *gin.Context) {
 
 	h := c.Query("height")
 	if h == "" {
-		e := deps.NewError(
+		e := apierrors.New(
 			"block",
 			fmt.Errorf("missing height"),
 			http.StatusBadRequest,
@@ -49,7 +50,7 @@ func GetBlock(c *gin.Context) {
 
 	hh, err := strconv.ParseInt(h, 10, 64)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"block",
 			fmt.Errorf("malformed height"),
 			http.StatusBadRequest,
@@ -71,7 +72,7 @@ func GetBlock(c *gin.Context) {
 
 	bd, err := bs.Block(hh)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"block",
 			fmt.Errorf("cannot get block at height %v", hh),
 			http.StatusBadRequest,

--- a/api/block/api.go
+++ b/api/block/api.go
@@ -42,8 +42,6 @@ func GetBlock(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query block, missing height",
-			"id",
-			e.ID,
 		)
 		return
 	}
@@ -58,8 +56,6 @@ func GetBlock(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query block, malformed height",
-			"id",
-			e.ID,
 			"height_string",
 			h,
 			"error",
@@ -80,8 +76,6 @@ func GetBlock(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query block from redis",
-			"id",
-			e.ID,
 			"height",
 			hh,
 			"error",

--- a/api/cached/api.go
+++ b/api/cached/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/gin-gonic/gin"
 	_ "github.com/gravity-devs/liquidity/x/liquidity/types"
 )
@@ -32,7 +33,7 @@ func getPools(c *gin.Context) {
 
 	res, err := d.Store.GetPools()
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"pools",
 			fmt.Errorf("cannot retrieve pools"),
 			http.StatusBadRequest,
@@ -66,7 +67,7 @@ func getParams(c *gin.Context) {
 
 	res, err := d.Store.GetParams()
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"params",
 			fmt.Errorf("cannot retrieve params"),
 			http.StatusBadRequest,
@@ -100,7 +101,7 @@ func getSupply(c *gin.Context) {
 
 	res, err := d.Store.GetSupply()
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"supply",
 			fmt.Errorf("cannot retrieve total supply"),
 			http.StatusBadRequest,
@@ -134,7 +135,7 @@ func getNodeInfo(c *gin.Context) {
 
 	res, err := d.Store.GetNodeInfo()
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"node_info",
 			fmt.Errorf("cannot retrieve node_info"),
 			http.StatusBadRequest,

--- a/api/cached/api.go
+++ b/api/cached/api.go
@@ -41,8 +41,6 @@ func getPools(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query pools",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -75,8 +73,6 @@ func getParams(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve params",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -109,8 +105,6 @@ func getSupply(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve total supply",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -143,8 +137,6 @@ func getNodeInfo(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve node_info",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)

--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -68,8 +68,6 @@ func GetChainMiddleware(chainNameParamKey string) gin.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve chain",
-				"id",
-				e.ID,
 				"name",
 				chainName,
 				"error",
@@ -106,8 +104,6 @@ func RequireChainEnabled(chainNameParamKey string) gin.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve chain",
-				"id",
-				e.ID,
 				"name",
 				chainName,
 				"error",

--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -59,7 +60,7 @@ func GetChainMiddleware(chainNameParamKey string) gin.HandlerFunc {
 
 		chain, err := d.Database.Chain(chainName)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot retrieve chain with name %v", chainName),
 				http.StatusBadRequest,
@@ -93,7 +94,7 @@ func RequireChainEnabled(chainNameParamKey string) gin.HandlerFunc {
 		chainName := c.Param(chainNameParamKey)
 
 		if exists, err := d.Database.ChainExists(chainName); err != nil || !exists {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot retrieve chain with name %v", chainName),
 				http.StatusBadRequest,

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -373,8 +373,6 @@ func VerifyTrace(c *gin.Context) {
 
 				d.WriteError(c, e1,
 					"invalid number of query responses",
-					"id",
-					e1.ID,
 					"hash",
 					hash,
 				)
@@ -666,7 +664,6 @@ func GetDenomSupply(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id", e.ID,
 			"name", chain.ChainName,
 			"error", err,
 		)
@@ -693,7 +690,6 @@ func GetDenomSupply(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve denom supply from sdk-service",
-			"id", e.ID,
 			"chain name", chain.ChainName,
 			"denom name", denom,
 			"error", err,
@@ -1368,7 +1364,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve denom supply from sdk-service",
-				"id", e.ID,
 				"chain name", chain.ChainName,
 				"denom name", bond_denom,
 				"error", err,

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -55,8 +55,6 @@ func GetChains(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chains",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -136,8 +134,6 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"counterparty",
@@ -182,8 +178,6 @@ func GetPrimaryChannels(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -292,8 +286,6 @@ func VerifyTrace(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query list of chain ids",
-			"id",
-			e.ID,
 			"hash",
 			hash,
 			"path",
@@ -433,8 +425,6 @@ func VerifyTrace(c *gin.Context) {
 
 		d.WriteError(c, e,
 			fmt.Sprintf("cannot query chain with name %s", nextChain),
-			"id",
-			e.ID,
 			"hash",
 			hash,
 			"path",
@@ -460,8 +450,6 @@ func VerifyTrace(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain last block time",
-			"id",
-			e.ID,
 			"hash",
 			hash,
 			"path",
@@ -593,8 +581,6 @@ func GetChainSupply(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -622,8 +608,6 @@ func GetChainSupply(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve supply from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -748,8 +732,6 @@ func GetChainTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -773,8 +755,6 @@ func GetChainTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve tx from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -813,8 +793,6 @@ func GetNumbersByAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query nodes auth for address",
-			"id",
-			e.ID,
 			"address",
 			address,
 			"error",
@@ -853,8 +831,6 @@ func GetInflation(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -877,8 +853,6 @@ func GetInflation(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve inflation from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -915,8 +889,6 @@ func GetStakingParams(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -939,8 +911,6 @@ func GetStakingParams(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve staking params from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -977,8 +947,6 @@ func GetStakingPool(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1001,8 +969,6 @@ func GetStakingPool(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve staking pool from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1038,8 +1004,6 @@ func GetMintParams(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1062,8 +1026,6 @@ func GetMintParams(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve mint params from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1099,8 +1061,6 @@ func GetAnnualProvisions(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1123,8 +1083,6 @@ func GetAnnualProvisions(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve mint annual provision from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1161,8 +1119,6 @@ func GetEpochProvisions(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1185,8 +1141,6 @@ func GetEpochProvisions(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve mint epoch provisions from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chain.ChainName,
 			"error",
@@ -1230,8 +1184,6 @@ func GetStakingAPR(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot get APR",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -1251,8 +1203,6 @@ func GetStakingAPR(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot convert apr to float",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -1282,8 +1232,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve chain's sdk-service",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1307,8 +1255,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve staking pool from sdk-service",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1329,8 +1275,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot unmarshal staking pool",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1350,8 +1294,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot convert bonded_tokens to int",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1375,8 +1317,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve staking params from sdk-service",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1397,8 +1337,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot unmarshal staking params",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1451,8 +1389,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot convert amount to coin",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1477,8 +1413,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot retrieve inflation from sdk-service",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1499,8 +1433,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot unmarshal inflation",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",
@@ -1520,8 +1452,6 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 			d.WriteError(c, e,
 				"cannot convert inflation to float64",
-				"id",
-				e.ID,
 				"name",
 				chain.ChainName,
 				"error",

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -17,6 +17,7 @@ import (
 	"github.com/emerishq/demeris-api-server/api/apiutils"
 	"github.com/emerishq/demeris-api-server/api/database"
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/demeris-api-server/lib/ginutils"
 	"github.com/emerishq/demeris-api-server/lib/stringcache"
 	"github.com/emerishq/demeris-api-server/sdkservice"
@@ -46,7 +47,7 @@ func GetChains(c *gin.Context) {
 	chains, err := d.Database.SimpleChains()
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve chains"),
 			http.StatusBadRequest,
@@ -127,7 +128,7 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 	counterparty := c.Param("counterparty")
 	chain, err := d.Database.PrimaryChannelCounterparty(chainName, counterparty)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"primarychannel",
 			fmt.Errorf("cannot retrieve primary channel between %v and %v", chainName, counterparty),
 			http.StatusBadRequest,
@@ -173,7 +174,7 @@ func GetPrimaryChannels(c *gin.Context) {
 	chainName := c.Param("chain")
 	chain, err := d.Database.PrimaryChannels(chainName)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"primarychannel",
 			fmt.Errorf("cannot retrieve primary channels for %v", chainName),
 			http.StatusBadRequest,
@@ -283,7 +284,7 @@ func VerifyTrace(c *gin.Context) {
 
 		err = fmt.Errorf("cannot query list of chain ids, %w", err)
 
-		e := deps.NewError(
+		e := apierrors.New(
 			"denom/verify-trace",
 			fmt.Errorf("cannot query list of chain ids"),
 			http.StatusBadRequest,
@@ -372,7 +373,7 @@ func VerifyTrace(c *gin.Context) {
 
 				c.JSON(http.StatusOK, res)
 			} else {
-				e1 := deps.NewError(
+				e1 := apierrors.New(
 					"denom/verify-trace",
 					fmt.Errorf("failed querying for %s, error: %w", hash, err),
 					http.StatusBadRequest,
@@ -424,7 +425,7 @@ func VerifyTrace(c *gin.Context) {
 			return
 		}
 
-		e := deps.NewError(
+		e := apierrors.New(
 			"denom/verify-trace",
 			fmt.Errorf("database error, %w", err),
 			http.StatusInternalServerError,
@@ -451,7 +452,7 @@ func VerifyTrace(c *gin.Context) {
 
 	cbt, err := d.Database.ChainLastBlock(nextChain)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"denom/verify-trace",
 			fmt.Errorf("cannot retrieve chain status for %v", nextChain),
 			http.StatusInternalServerError,
@@ -584,7 +585,7 @@ func GetChainSupply(c *gin.Context) {
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -613,7 +614,7 @@ func GetChainSupply(c *gin.Context) {
 
 	sdkRes, err := client.Supply(context.Background(), payload)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve supply from sdk-service"),
 			http.StatusBadRequest,
@@ -673,7 +674,7 @@ func GetDenomSupply(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -700,7 +701,7 @@ func GetDenomSupply(c *gin.Context) {
 		if len(sdkRes.Coins) != 1 {
 			cause = fmt.Errorf("expected 1 denom for chain: %s - denom: %s, found %v", chain.ChainName, denom, sdkRes.Coins)
 		}
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			cause,
 			http.StatusBadRequest,
@@ -739,7 +740,7 @@ func GetChainTx(c *gin.Context) {
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -764,7 +765,7 @@ func GetChainTx(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
@@ -804,7 +805,7 @@ func GetNumbersByAddress(c *gin.Context) {
 
 	resp, err := apiutils.FetchAccountNumbers(chainInfo, address)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"numbers",
 			fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusBadRequest,
@@ -844,7 +845,7 @@ func GetInflation(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -868,7 +869,7 @@ func GetInflation(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve inflation from sdk-service"),
 			http.StatusBadRequest,
@@ -906,7 +907,7 @@ func GetStakingParams(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -930,7 +931,7 @@ func GetStakingParams(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve staking params from sdk-service"),
 			http.StatusBadRequest,
@@ -968,7 +969,7 @@ func GetStakingPool(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -992,7 +993,7 @@ func GetStakingPool(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve staking pool from sdk-service"),
 			http.StatusBadRequest,
@@ -1029,7 +1030,7 @@ func GetMintParams(c *gin.Context) {
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -1053,7 +1054,7 @@ func GetMintParams(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve mint params from sdk-service"),
 			http.StatusBadRequest,
@@ -1090,7 +1091,7 @@ func GetAnnualProvisions(c *gin.Context) {
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -1114,7 +1115,7 @@ func GetAnnualProvisions(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve mint annual provision from sdk-service"),
 			http.StatusBadRequest,
@@ -1152,7 +1153,7 @@ func GetEpochProvisions(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
@@ -1176,7 +1177,7 @@ func GetEpochProvisions(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve mint epoch provisions from sdk-service"),
 			http.StatusBadRequest,
@@ -1221,7 +1222,7 @@ func GetStakingAPR(c *gin.Context) {
 	)
 	aprString, err := aprCache.Get(c.Request.Context(), chainName)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot get APR"),
 			http.StatusBadRequest,
@@ -1242,7 +1243,7 @@ func GetStakingAPR(c *gin.Context) {
 
 	apr, err := strconv.ParseFloat(aprString, 64)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot convert apr to float"),
 			http.StatusBadRequest,
@@ -1273,7 +1274,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 		client, err := sdkservice.Client(chain.MajorSDKVersion())
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 				http.StatusBadRequest,
@@ -1298,7 +1299,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		})
 
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot retrieve staking pool from sdk-service"),
 				http.StatusBadRequest,
@@ -1320,7 +1321,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		var stakingPoolData StakingPoolResponse
 		err = json.Unmarshal(stakingPoolRes.StakingPool, &stakingPoolData)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot unmarshal staking pool"),
 				http.StatusBadRequest,
@@ -1341,7 +1342,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 		bondedTokens, err := strconv.Atoi(stakingPoolData.Pool.BondedTokens)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot convert bonded_tokens to int"),
 				http.StatusBadRequest,
@@ -1366,7 +1367,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		})
 
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot retrieve staking params from sdk-service"),
 				http.StatusBadRequest,
@@ -1388,7 +1389,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		var stakingParamsData StakingParamsResponse
 		err = json.Unmarshal(stakingParamsRes.StakingParams, &stakingParamsData)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot unmarshal staking params"),
 				http.StatusBadRequest,
@@ -1421,7 +1422,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 			if len(denomSupplyRes.Coins) != 1 {
 				cause = fmt.Errorf("expected 1 denom for chain: %s - denom: %s, found %v", chain.ChainName, bond_denom, denomSupplyRes.Coins)
 			}
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				cause,
 				http.StatusBadRequest,
@@ -1442,7 +1443,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		// Hence, converting it to type coin to extract amount
 		coin, err := sdktypes.ParseCoinNormalized(denomSupplyRes.Coins[0].Amount)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot convert amount to coin"),
 				http.StatusBadRequest,
@@ -1468,7 +1469,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		})
 
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot retrieve inflation from sdk-service"),
 				http.StatusBadRequest,
@@ -1490,7 +1491,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		var inflationData InflationResponse
 		err = json.Unmarshal(inflationRes.MintInflation, &inflationData)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot unmarshal inflation"),
 				http.StatusBadRequest,
@@ -1511,7 +1512,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 		inflation, err := strconv.ParseFloat(inflationData.Inflation, 64)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"chains",
 				fmt.Errorf("cannot convert inflation to float64"),
 				http.StatusBadRequest,

--- a/api/chains/fee.go
+++ b/api/chains/fee.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,7 +29,7 @@ func GetFee(c *gin.Context) {
 	chain, err := d.Database.Chain(chainName)
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"fee",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
@@ -74,7 +75,7 @@ func GetFeeAddress(c *gin.Context) {
 	chain, err := d.Database.Chain(chainName)
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"feeaddress",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
@@ -117,7 +118,7 @@ func GetFeeAddresses(c *gin.Context) {
 	chains, err := d.Database.Chains()
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"feeaddress",
 			fmt.Errorf("cannot retrieve chains"),
 			http.StatusBadRequest,
@@ -167,7 +168,7 @@ func GetFeeToken(c *gin.Context) {
 	chain, err := d.Database.Chain(chainName)
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"feetoken",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,

--- a/api/chains/fee.go
+++ b/api/chains/fee.go
@@ -37,8 +37,6 @@ func GetFee(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -83,8 +81,6 @@ func GetFeeAddress(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -126,8 +122,6 @@ func GetFeeAddresses(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chains",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -176,8 +170,6 @@ func GetFeeToken(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",

--- a/api/chains/validators.go
+++ b/api/chains/validators.go
@@ -43,8 +43,6 @@ func GetValidators(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve validators",
-			"id",
-			e.ID,
 			"error",
 			err,
 			"chain",

--- a/api/chains/validators.go
+++ b/api/chains/validators.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/demeris-api-server/lib/keybase"
 	"github.com/emerishq/demeris-api-server/lib/stringcache"
 	"github.com/emerishq/demeris-backend-models/tracelistener"
@@ -34,7 +35,7 @@ func GetValidators(c *gin.Context) {
 	chainName := c.Param("chain")
 	validators, err := d.Database.GetValidators(chainName)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"validators",
 			fmt.Errorf("cannot retrieve validators"),
 			http.StatusBadRequest,

--- a/api/liquidity/api.go
+++ b/api/liquidity/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/emeris-utils/exported/sdktypes"
 	"github.com/gin-gonic/gin"
 )
@@ -33,7 +34,7 @@ func getSwapFee(c *gin.Context) {
 
 	res, err := d.Store.GetSwapFees(poolId)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"swap fees",
 			fmt.Errorf("cannot get swap fees"),
 			http.StatusBadRequest,

--- a/api/liquidity/api.go
+++ b/api/liquidity/api.go
@@ -42,8 +42,6 @@ func getSwapFee(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot get swap fees",
-			"id",
-			e.ID,
 			"poolId",
 			poolId,
 			"error",

--- a/api/relayer/api.go
+++ b/api/relayer/api.go
@@ -12,6 +12,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/emerishq/demeris-api-server/api/database"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	cnsmodels "github.com/emerishq/demeris-backend-models/cns"
 
 	v1 "github.com/allinbits/starport-operator/api/v1"
@@ -47,7 +48,7 @@ func getRelayerStatus(c *gin.Context) {
 	}.String())
 
 	if err != nil && !errors.Is(err, k8s.ErrNotFound) {
-		e := deps.NewError(
+		e := apierrors.New(
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
@@ -68,7 +69,7 @@ func getRelayerStatus(c *gin.Context) {
 
 	relayer, err := k8s.GetRelayerFromObj(obj)
 	if err != nil && !errors.Is(err, k8s.ErrNotFound) {
-		e := deps.NewError(
+		e := apierrors.New(
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
@@ -114,7 +115,7 @@ func getRelayerBalance(c *gin.Context) {
 	}.String())
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
@@ -135,7 +136,7 @@ func getRelayerBalance(c *gin.Context) {
 
 	relayer, err := k8s.GetRelayerFromObj(obj)
 	if err != nil && !errors.Is(err, k8s.ErrNotFound) {
-		e := deps.NewError(
+		e := apierrors.New(
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
@@ -161,7 +162,7 @@ func getRelayerBalance(c *gin.Context) {
 
 	thresh, err := relayerThresh(chains, d.Database)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"status",
 			fmt.Errorf("cannot retrieve relayer status"),
 			http.StatusBadRequest,
@@ -186,7 +187,7 @@ func getRelayerBalance(c *gin.Context) {
 
 		enough, err := enoughBalance(addresses[i], t, d.Database)
 		if err != nil {
-			e := deps.NewError(
+			e := apierrors.New(
 				"status",
 				fmt.Errorf("cannot retrieve relayer status"),
 				http.StatusBadRequest,

--- a/api/relayer/api.go
+++ b/api/relayer/api.go
@@ -56,8 +56,6 @@ func getRelayerStatus(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query relayer status",
-			"id",
-			e.ID,
 			"error",
 			err,
 			"obj",
@@ -77,8 +75,6 @@ func getRelayerStatus(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot unstructure relayer status",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -123,8 +119,6 @@ func getRelayerBalance(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot query relayer status",
-			"id",
-			e.ID,
 			"error",
 			err,
 			"obj",
@@ -144,8 +138,6 @@ func getRelayerBalance(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot unstructure relayer status",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -170,8 +162,6 @@ func getRelayerBalance(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve relayer status",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -195,8 +185,6 @@ func getRelayerBalance(c *gin.Context) {
 
 			d.WriteError(c, e,
 				"cannot retrieve relayer status",
-				"id",
-				e.ID,
 				"error",
 				err,
 			)

--- a/api/router/deps/deps.go
+++ b/api/router/deps/deps.go
@@ -5,6 +5,7 @@ import (
 	kube "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/emerishq/demeris-api-server/api/database"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/demeris-api-server/lib/ginutils"
 	"github.com/emerishq/emeris-utils/logging"
 	"github.com/emerishq/emeris-utils/store"
@@ -37,7 +38,7 @@ func GetDeps(c *gin.Context) *Deps {
 }
 
 // WriteError logs and return client-facing errors
-func (d *Deps) WriteError(c *gin.Context, err Error, logMessage string, keyAndValues ...interface{}) {
+func (d *Deps) WriteError(c *gin.Context, err apierrors.Error, logMessage string, keyAndValues ...interface{}) {
 
 	// setting error id
 	value, ok := c.Request.Context().Value(logging.IntCorrelationIDName).(string)

--- a/api/router/deps/deps.go
+++ b/api/router/deps/deps.go
@@ -37,15 +37,8 @@ func GetDeps(c *gin.Context) *Deps {
 	return deps
 }
 
-// WriteError logs and return client-facing errors
+// WriteError adds an error to the gin context and logs it.
 func (d *Deps) WriteError(c *gin.Context, err apierrors.Error, logMessage string, keyAndValues ...interface{}) {
-
-	// setting error id
-	value, ok := c.Request.Context().Value(logging.IntCorrelationIDName).(string)
-	if !ok {
-		panic("cant get value int_correlation_id")
-	}
-	err.ID = value
 	_ = c.Error(err)
 
 	if keyAndValues != nil {

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/emerishq/demeris-api-server/api/block"
 	"github.com/emerishq/demeris-api-server/api/cached"
 	"github.com/emerishq/demeris-api-server/api/liquidity"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"k8s.io/client-go/informers"
 
 	"github.com/emerishq/demeris-api-server/api/relayer"
@@ -94,7 +95,7 @@ func (r *Router) catchPanicsFunc(c *gin.Context) {
 	defer func() {
 		if rval := recover(); rval != nil {
 			// okay we panic-ed, log it through r's logger and write back internal server error
-			err := deps.NewError(
+			err := apierrors.New(
 				"fatal_error",
 				errors.New("internal server error"),
 				http.StatusInternalServerError)
@@ -138,7 +139,7 @@ func (r *Router) handleErrors(c *gin.Context) {
 		return
 	}
 
-	rerr := deps.Error{}
+	rerr := apierrors.Error{}
 	if !errors.As(l, &rerr) {
 		panic(l)
 	}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -105,7 +105,6 @@ func (r *Router) catchPanicsFunc(c *gin.Context) {
 				"panic handler triggered while handling call",
 				"endpoint", c.Request.RequestURI,
 				"error", fmt.Sprint(rval),
-				"error_id", err.ID,
 			)
 
 			userError := apierrors.NewUserFacingError(tryGetIntCorrelationID(c), err)

--- a/api/tx/api.go
+++ b/api/tx/api.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/demeris-api-server/sdkservice"
 	"github.com/emerishq/emeris-utils/exported/sdktypes"
 	sdkutilities "github.com/emerishq/sdk-service-meta/gen/sdk_utilities"
@@ -40,7 +41,7 @@ func Tx(c *gin.Context) {
 	err := c.BindJSON(&txRequest)
 
 	if err != nil {
-		e := deps.NewError("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest)
+		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest)
 
 		d.WriteError(c, e,
 			"Failed to parse JSON",
@@ -55,7 +56,7 @@ func Tx(c *gin.Context) {
 
 	chain, err := d.Database.Chain(chainName)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
@@ -76,7 +77,7 @@ func Tx(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
@@ -98,7 +99,7 @@ func Tx(c *gin.Context) {
 	txhash, err := relayTx(client, d, txRequest.TxBytes, chainName, txRequest.Owner)
 
 	if err != nil {
-		e := deps.NewError("tx", fmt.Errorf("relaying tx failed, %w", err), http.StatusBadRequest)
+		e := apierrors.New("tx", fmt.Errorf("relaying tx failed, %w", err), http.StatusBadRequest)
 
 		d.WriteError(c, e,
 			"relaying tx failed",
@@ -159,7 +160,7 @@ func GetTicket(c *gin.Context) {
 	ticket, err := d.Store.Get(fmt.Sprintf("%s/%s", chainName, ticketId))
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"tx",
 			fmt.Errorf("cannot retrieve ticket with id %v", ticketId),
 			http.StatusBadRequest,
@@ -199,7 +200,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 	err := c.BindJSON(&txRequest)
 	if err != nil {
-		e := deps.NewError("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest)
+		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest)
 
 		d.WriteError(c, e,
 			"Failed to parse JSON",
@@ -214,7 +215,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 	chain, err := d.Database.Chain(chainName)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
@@ -235,7 +236,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
@@ -260,7 +261,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot estimate fees from sdk-service"),
 			http.StatusBadRequest,

--- a/api/tx/api.go
+++ b/api/tx/api.go
@@ -45,8 +45,6 @@ func Tx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"Failed to parse JSON",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -64,8 +62,6 @@ func Tx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -85,8 +81,6 @@ func Tx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -103,8 +97,6 @@ func Tx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"relaying tx failed",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -168,8 +160,6 @@ func GetTicket(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve ticket",
-			"id",
-			e.ID,
 			"name",
 			ticketId,
 			"error",
@@ -204,8 +194,6 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"Failed to parse JSON",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)
@@ -223,8 +211,6 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -244,8 +230,6 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chain's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",
@@ -269,8 +253,6 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot estimate fees from sdk-service",
-			"id",
-			e.ID,
 			"name",
 			chainName,
 			"error",

--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -68,8 +68,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve srcChainInfo",
-			"id",
-			e.ID,
 			"name",
 			srcChain,
 			"error",
@@ -90,8 +88,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve srcChainInfo",
-			"id",
-			e.ID,
 			"name",
 			destChain,
 			"error",
@@ -111,8 +107,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve srcChainInfo's sdk-service",
-			"id",
-			e.ID,
 			"name",
 			srcChain,
 			"error",
@@ -136,8 +130,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve tx from sdk-service",
-			"id",
-			e.ID,
 			"txHash",
 			txHash,
 			"src srcChainInfo name",
@@ -164,8 +156,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"provided transaction is not ibc transfer",
-			"id",
-			e.ID,
 			"txHash",
 			txHash,
 			"src srcChainInfo name",
@@ -195,8 +185,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve destination tx",
-			"id",
-			e.ID,
 			"txHash",
 			txHash,
 			"dest srcChainInfo name",
@@ -221,8 +209,6 @@ func GetDestTx(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve destination tx",
-			"id",
-			e.ID,
 			"txHash",
 			txHash,
 			"dest srcChainInfo name",

--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/emerishq/demeris-api-server/sdkservice"
 	sdkutilities "github.com/emerishq/sdk-service-meta/gen/sdk_utilities"
 	"github.com/gin-gonic/gin"
@@ -59,7 +60,7 @@ func GetDestTx(c *gin.Context) {
 
 	srcChainInfo, err := d.Database.Chain(srcChain)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve srcChainInfo with name %v", srcChain),
 			http.StatusBadRequest,
@@ -81,7 +82,7 @@ func GetDestTx(c *gin.Context) {
 	// validate destination srcChainInfo is present
 	destChainInfo, err := d.Database.Chain(destChain)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve srcChainInfo with name %v", destChain),
 			http.StatusBadRequest,
@@ -102,7 +103,7 @@ func GetDestTx(c *gin.Context) {
 
 	client, err := sdkservice.Client(srcChainInfo.MajorSDKVersion())
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with srcChainInfo name %v", srcChainInfo.CosmosSDKVersion, srcChainInfo.ChainName),
 			http.StatusBadRequest,
@@ -127,7 +128,7 @@ func GetDestTx(c *gin.Context) {
 	})
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
@@ -155,7 +156,7 @@ func GetDestTx(c *gin.Context) {
 	// for now we just get the first seq number found and roll with it.
 	r := getIBCSeqFromTx(sdkRes)
 	if len(r) == 0 {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("provided transaction is not ibc transfer"),
 			http.StatusBadRequest,
@@ -186,7 +187,7 @@ func GetDestTx(c *gin.Context) {
 	// we're validating inputs and hence gosec-G107 can be ignored
 	resp, err := httpClient.Get(url) // nolint: gosec
 	if err != nil || resp.StatusCode != http.StatusOK {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
@@ -212,7 +213,7 @@ func GetDestTx(c *gin.Context) {
 
 	bz, err := io.ReadAll(resp.Body)
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"chains",
 			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,

--- a/api/verifieddenoms/api.go
+++ b/api/verifieddenoms/api.go
@@ -38,8 +38,6 @@ func GetVerifiedDenoms(c *gin.Context) {
 
 		d.WriteError(c, e,
 			"cannot retrieve chains",
-			"id",
-			e.ID,
 			"error",
 			err,
 		)

--- a/api/verifieddenoms/api.go
+++ b/api/verifieddenoms/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/emerishq/demeris-api-server/api/router/deps"
+	"github.com/emerishq/demeris-api-server/lib/apierrors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -29,7 +30,7 @@ func GetVerifiedDenoms(c *gin.Context) {
 	chains, err := d.Database.Chains()
 
 	if err != nil {
-		e := deps.NewError(
+		e := apierrors.New(
 			"verified_denoms",
 			fmt.Errorf("cannot retrieve chains"),
 			http.StatusBadRequest,

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -5,7 +5,6 @@ import (
 )
 
 type Error struct {
-	ID            string `json:"id"`
 	Namespace     string `json:"namespace"`
 	StatusCode    int    `json:"-"`
 	LowLevelError error  `json:"-"`
@@ -13,7 +12,7 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("%s @ %s: %s", e.ID, e.Namespace, e.LowLevelError.Error())
+	return fmt.Sprintf("%s: %s", e.Namespace, e.LowLevelError.Error())
 }
 
 func (e Error) Unwrap() error {

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -1,4 +1,4 @@
-package deps
+package apierrors
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ func (e Error) Unwrap() error {
 	return e.LowLevelError
 }
 
-func NewError(namespace string, cause error, statusCode int) Error {
+func New(namespace string, cause error, statusCode int) Error {
 	return Error{
 		StatusCode:    statusCode,
 		Namespace:     namespace,

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -5,10 +5,10 @@ import (
 )
 
 type Error struct {
-	Namespace     string `json:"namespace"`
-	StatusCode    int    `json:"-"`
-	LowLevelError error  `json:"-"`
-	Cause         string `json:"cause"`
+	Namespace     string
+	StatusCode    int
+	LowLevelError error
+	Cause         string
 }
 
 func (e Error) Error() string {

--- a/lib/apierrors/user_error.go
+++ b/lib/apierrors/user_error.go
@@ -1,0 +1,18 @@
+package apierrors
+
+// UserFacingError is a struct that can be returned as an API response in case
+// of errors. The cause should not leak any implementation detail to the user
+// but can be informative of what went wrong.
+type UserFacingError struct {
+	ID        string `json:"id"`
+	Namespace string `json:"namespace"`
+	Cause     string `json:"cause"`
+}
+
+func NewUserFacingError(id string, e Error) UserFacingError {
+	return UserFacingError{
+		ID:        id,
+		Namespace: e.Namespace,
+		Cause:     e.Cause,
+	}
+}


### PR DESCRIPTION
I'm trying to clean the code around error creation, error logging, and error responses to the user.

In this PR I have:
- moved the custom Error struct to its own package
- created a separate struct for "user facing errors" (= the json returned in case of errors)
- remove the ID from our Error struct, it will be middlewares' responsability to set up the logger to log that id, and to populate the ID field when returning the error to the user