### PR TITLE
test: disable parallelism when using shared database

### DIFF
--- a/api/chains/chains_test.go
+++ b/api/chains/chains_test.go
@@ -64,8 +64,6 @@ func TestGetChain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			// arrange
 			// if we have a populated Chain store, add it
 			if !cmp.Equal(tt.dataStruct, cns.Chain{}) {
@@ -104,8 +102,6 @@ func TestGetChain(t *testing.T) {
 func TestGetChains(t *testing.T) {
 	for _, tt := range getChainsTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			// arrange
 			// if we have a populated Chain store, add it
 			if len(tt.dataStruct) != 0 {
@@ -142,8 +138,6 @@ func TestGetChains(t *testing.T) {
 }
 
 func TestVerifyTrace(t *testing.T) {
-	t.Parallel()
-
 	utils.RunTraceListnerMigrations(testingCtx, t)
 
 	for i, tt := range verifyTraceTestCases {
@@ -226,7 +220,6 @@ func TestGetChainStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			// arrange
 			// if we have a populated Chain store, add it
 			if !cmp.Equal(tt.dataStruct, cns.Chain{}) {
@@ -282,7 +275,6 @@ func TestGetChainSupply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			// arrange
 			// if we have a populated Chain store, add it
 			if !cmp.Equal(tt.dataStruct, cns.Chain{}) {

--- a/api/chains/chains_test.go
+++ b/api/chains/chains_test.go
@@ -183,6 +183,8 @@ func toSupportedChain(c cns.Chain) chains.SupportedChain {
 }
 
 func TestGetChainStatus(t *testing.T) {
+	utils.RunTraceListnerMigrations(testingCtx, t)
+	utils.InsertTraceListnerData(testingCtx, t, verifyTraceData)
 
 	tests := []struct {
 		name             string
@@ -254,7 +256,6 @@ func TestGetChainStatus(t *testing.T) {
 }
 
 func TestGetChainSupply(t *testing.T) {
-
 	tests := []struct {
 		name             string
 		dataStruct       cns.Chain


### PR DESCRIPTION
Code coverage check is super flaky because we run parallel tests against a shared database. I disabled parallelism since we can't ensure reproducibility.