### PR TITLE
refactor: write errors in middleware instead of doing manually

### DIFF
--- a/api/account/api.go
+++ b/api/account/api.go
@@ -53,15 +53,14 @@ func GetBalancesByAddress(c *gin.Context) {
 			"account",
 			fmt.Errorf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query database balance for address",
 			"address",
 			address,
 			"error",
 			err,
 		)
+		c.Error(e)
 		return
 	}
 
@@ -71,15 +70,14 @@ func GetBalancesByAddress(c *gin.Context) {
 			"account",
 			fmt.Errorf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query database verified denoms",
 			"address",
 			address,
 			"error",
 			err,
 		)
+		c.Error(e)
 		return
 	}
 
@@ -182,15 +180,14 @@ func GetDelegationsByAddress(c *gin.Context) {
 			"delegations",
 			fmt.Errorf("cannot retrieve delegations for address %v", address),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query database delegations for addresses",
 			"address",
 			address,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -230,15 +227,14 @@ func GetUnbondingDelegationsByAddress(c *gin.Context) {
 			"unbonding delegations",
 			fmt.Errorf("cannot retrieve unbonding delegations for address %v", address),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query database unbonding delegations for addresses",
 			"address",
 			address,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -281,15 +277,14 @@ func GetDelegatorRewards(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -300,15 +295,14 @@ func GetDelegatorRewards(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -324,15 +318,14 @@ func GetDelegatorRewards(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve delegator rewards from sdk-service"),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve delegator rewards from sdk-service",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -398,9 +391,7 @@ func GetNumbersByAddress(c *gin.Context) {
 				"numbers",
 				fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot query database auth for addresses",
 				"address",
 				address,
@@ -417,15 +408,14 @@ func GetNumbersByAddress(c *gin.Context) {
 			"numbers",
 			fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query nodes auth for addresses",
 			"address",
 			address,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -446,15 +436,14 @@ func GetUserTickets(c *gin.Context) {
 			"tickets",
 			fmt.Errorf("cannot retrieve tickets for address %v", address),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query store for tickets",
 			"address",
 			address,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/account/api.go
+++ b/api/account/api.go
@@ -51,7 +51,7 @@ func GetBalancesByAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"account",
-			fmt.Errorf("cannot retrieve account for address %v", address),
+			fmt.Sprintf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query database balance for address",
@@ -68,7 +68,7 @@ func GetBalancesByAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"account",
-			fmt.Errorf("cannot retrieve account for address %v", address),
+			fmt.Sprintf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query database verified denoms",
@@ -178,7 +178,7 @@ func GetDelegationsByAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"delegations",
-			fmt.Errorf("cannot retrieve delegations for address %v", address),
+			fmt.Sprintf("cannot retrieve delegations for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query database delegations for addresses",
@@ -225,7 +225,7 @@ func GetUnbondingDelegationsByAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"unbonding delegations",
-			fmt.Errorf("cannot retrieve unbonding delegations for address %v", address),
+			fmt.Sprintf("cannot retrieve unbonding delegations for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query database unbonding delegations for addresses",
@@ -275,7 +275,7 @@ func GetDelegatorRewards(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve chain with name %v", chainName),
+			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -293,7 +293,7 @@ func GetDelegatorRewards(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -316,7 +316,7 @@ func GetDelegatorRewards(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve delegator rewards from sdk-service"),
+			fmt.Sprintf("cannot retrieve delegator rewards from sdk-service"),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot retrieve delegator rewards from sdk-service",
@@ -389,7 +389,7 @@ func GetNumbersByAddress(c *gin.Context) {
 		if err != nil {
 			e := apierrors.New(
 				"numbers",
-				fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
+				fmt.Sprintf("cannot retrieve account/sequence numbers for address %v", address),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot query database auth for addresses",
@@ -406,7 +406,7 @@ func GetNumbersByAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"numbers",
-			fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
+			fmt.Sprintf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot query nodes auth for addresses",
@@ -434,7 +434,7 @@ func GetUserTickets(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"tickets",
-			fmt.Errorf("cannot retrieve tickets for address %v", address),
+			fmt.Sprintf("cannot retrieve tickets for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query store for tickets",

--- a/api/account/api.go
+++ b/api/account/api.go
@@ -54,11 +54,9 @@ func GetBalancesByAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query database balance for address",
+			fmt.Errorf("cannot query database balance for address: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 		)
 		c.Error(e)
 		return
@@ -71,11 +69,9 @@ func GetBalancesByAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve account for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query database verified denoms",
+			fmt.Errorf("cannot query database verified denoms: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 		)
 		c.Error(e)
 		return
@@ -181,11 +177,9 @@ func GetDelegationsByAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve delegations for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query database delegations for addresses",
+			fmt.Errorf("cannot query database delegations for addresses: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -228,11 +222,9 @@ func GetUnbondingDelegationsByAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve unbonding delegations for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query database unbonding delegations for addresses",
+			fmt.Errorf("cannot query database unbonding delegations for addresses: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -278,11 +270,9 @@ func GetDelegatorRewards(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -296,11 +286,9 @@ func GetDelegatorRewards(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -319,11 +307,9 @@ func GetDelegatorRewards(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve delegator rewards from sdk-service"),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot retrieve delegator rewards from sdk-service",
+			fmt.Errorf("cannot retrieve delegator rewards from sdk-service: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -392,11 +378,9 @@ func GetNumbersByAddress(c *gin.Context) {
 				fmt.Sprintf("cannot retrieve account/sequence numbers for address %v", address),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot query database auth for addresses",
+				fmt.Errorf("cannot query database auth for addresses: %w", err),
 				"address",
 				address,
-				"error",
-				err,
 			)
 
 			return
@@ -409,11 +393,9 @@ func GetNumbersByAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot query nodes auth for addresses",
+			fmt.Errorf("cannot query nodes auth for addresses: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -437,11 +419,9 @@ func GetUserTickets(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve tickets for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query store for tickets",
+			fmt.Errorf("cannot query store for tickets: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 		)
 		c.Error(e)
 

--- a/api/account/api.go
+++ b/api/account/api.go
@@ -58,7 +58,7 @@ func GetBalancesByAddress(c *gin.Context) {
 			"address",
 			address,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 
@@ -73,7 +73,7 @@ func GetBalancesByAddress(c *gin.Context) {
 			"address",
 			address,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 
@@ -181,7 +181,7 @@ func GetDelegationsByAddress(c *gin.Context) {
 			"address",
 			address,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -226,7 +226,7 @@ func GetUnbondingDelegationsByAddress(c *gin.Context) {
 			"address",
 			address,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -274,7 +274,7 @@ func GetDelegatorRewards(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -290,7 +290,7 @@ func GetDelegatorRewards(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -311,7 +311,7 @@ func GetDelegatorRewards(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -397,7 +397,7 @@ func GetNumbersByAddress(c *gin.Context) {
 			"address",
 			address,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -423,7 +423,7 @@ func GetUserTickets(c *gin.Context) {
 			"address",
 			address,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/block/api.go
+++ b/api/block/api.go
@@ -38,11 +38,10 @@ func GetBlock(c *gin.Context) {
 			"block",
 			fmt.Errorf("missing height"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query block, missing height",
 		)
+		c.Error(e)
 		return
 	}
 
@@ -52,15 +51,14 @@ func GetBlock(c *gin.Context) {
 			"block",
 			fmt.Errorf("malformed height"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query block, malformed height",
 			"height_string",
 			h,
 			"error",
 			err,
 		)
+		c.Error(e)
 		return
 	}
 
@@ -72,15 +70,14 @@ func GetBlock(c *gin.Context) {
 			"block",
 			fmt.Errorf("cannot get block at height %v", hh),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query block from redis",
 			"height",
 			hh,
 			"error",
 			err,
 		)
+		c.Error(e)
 		return
 	}
 

--- a/api/block/api.go
+++ b/api/block/api.go
@@ -36,7 +36,7 @@ func GetBlock(c *gin.Context) {
 	if h == "" {
 		e := apierrors.New(
 			"block",
-			fmt.Errorf("missing height"),
+			fmt.Sprintf("missing height"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query block, missing height",
@@ -49,7 +49,7 @@ func GetBlock(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"block",
-			fmt.Errorf("malformed height"),
+			fmt.Sprintf("malformed height"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query block, malformed height",
@@ -68,7 +68,7 @@ func GetBlock(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"block",
-			fmt.Errorf("cannot get block at height %v", hh),
+			fmt.Sprintf("cannot get block at height %v", hh),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query block from redis",

--- a/api/block/api.go
+++ b/api/block/api.go
@@ -41,7 +41,7 @@ func GetBlock(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot query block, missing height"),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 
@@ -56,7 +56,7 @@ func GetBlock(c *gin.Context) {
 			"height_string",
 			h,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 
@@ -73,7 +73,7 @@ func GetBlock(c *gin.Context) {
 			"height",
 			hh,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 

--- a/api/block/api.go
+++ b/api/block/api.go
@@ -39,7 +39,7 @@ func GetBlock(c *gin.Context) {
 			fmt.Sprintf("missing height"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query block, missing height",
+			fmt.Errorf("cannot query block, missing height"),
 		)
 		c.Error(e)
 		return
@@ -52,11 +52,9 @@ func GetBlock(c *gin.Context) {
 			fmt.Sprintf("malformed height"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query block, malformed height",
+			fmt.Errorf("cannot query block, malformed height: %w", err),
 			"height_string",
 			h,
-			"error",
-			err,
 		)
 		c.Error(e)
 		return
@@ -71,11 +69,9 @@ func GetBlock(c *gin.Context) {
 			fmt.Sprintf("cannot get block at height %v", hh),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query block from redis",
+			fmt.Errorf("cannot query block from redis: %w", err),
 			"height",
 			hh,
-			"error",
-			err,
 		)
 		c.Error(e)
 		return

--- a/api/cached/api.go
+++ b/api/cached/api.go
@@ -38,9 +38,7 @@ func getPools(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve pools"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query pools",
-			"error",
-			err,
+			fmt.Errorf("cannot query pools: %w", err),
 		)
 		c.Error(e)
 
@@ -69,9 +67,7 @@ func getParams(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve params"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve params",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve params: %w", err),
 		)
 		c.Error(e)
 
@@ -100,9 +96,7 @@ func getSupply(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve total supply"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve total supply",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve total supply: %w", err),
 		)
 		c.Error(e)
 
@@ -131,9 +125,7 @@ func getNodeInfo(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve node_info"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve node_info",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve node_info: %w", err),
 		)
 		c.Error(e)
 

--- a/api/cached/api.go
+++ b/api/cached/api.go
@@ -37,13 +37,12 @@ func getPools(c *gin.Context) {
 			"pools",
 			fmt.Errorf("cannot retrieve pools"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query pools",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -69,13 +68,12 @@ func getParams(c *gin.Context) {
 			"params",
 			fmt.Errorf("cannot retrieve params"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve params",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -101,13 +99,12 @@ func getSupply(c *gin.Context) {
 			"supply",
 			fmt.Errorf("cannot retrieve total supply"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve total supply",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -133,13 +130,12 @@ func getNodeInfo(c *gin.Context) {
 			"node_info",
 			fmt.Errorf("cannot retrieve node_info"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve node_info",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/cached/api.go
+++ b/api/cached/api.go
@@ -35,7 +35,7 @@ func getPools(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"pools",
-			fmt.Errorf("cannot retrieve pools"),
+			fmt.Sprintf("cannot retrieve pools"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query pools",
@@ -66,7 +66,7 @@ func getParams(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"params",
-			fmt.Errorf("cannot retrieve params"),
+			fmt.Sprintf("cannot retrieve params"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve params",
@@ -97,7 +97,7 @@ func getSupply(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"supply",
-			fmt.Errorf("cannot retrieve total supply"),
+			fmt.Sprintf("cannot retrieve total supply"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve total supply",
@@ -128,7 +128,7 @@ func getNodeInfo(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"node_info",
-			fmt.Errorf("cannot retrieve node_info"),
+			fmt.Sprintf("cannot retrieve node_info"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve node_info",

--- a/api/cached/api.go
+++ b/api/cached/api.go
@@ -40,7 +40,7 @@ func getPools(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot query pools: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -69,7 +69,7 @@ func getParams(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve params: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -98,7 +98,7 @@ func getSupply(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve total supply: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -127,7 +127,7 @@ func getNodeInfo(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve node_info: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -65,11 +65,9 @@ func GetChainMiddleware(chainNameParamKey string) gin.HandlerFunc {
 				fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve chain",
+				fmt.Errorf("cannot retrieve chain: %w", err),
 				"name",
 				chainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 			c.Abort()
@@ -104,8 +102,6 @@ func RequireChainEnabled(chainNameParamKey string) gin.HandlerFunc {
 				"cannot retrieve chain",
 				"name",
 				chainName,
-				"error",
-				err,
 			)
 
 			c.Abort()

--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -62,7 +62,7 @@ func GetChainMiddleware(chainNameParamKey string) gin.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot retrieve chain with name %v", chainName),
+				fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot retrieve chain",
@@ -92,7 +92,7 @@ func RequireChainEnabled(chainNameParamKey string) gin.HandlerFunc {
 		if exists, err := d.Database.ChainExists(chainName); err != nil || !exists {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot retrieve chain with name %v", chainName),
+				fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 				http.StatusBadRequest,
 			)
 

--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -69,7 +69,7 @@ func GetChainMiddleware(chainNameParamKey string) gin.HandlerFunc {
 				"name",
 				chainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 			c.Abort()
 			return
 		}
@@ -102,6 +102,8 @@ func RequireChainEnabled(chainNameParamKey string) gin.HandlerFunc {
 				"cannot retrieve chain",
 				"name",
 				chainName,
+				"error",
+				err,
 			)
 
 			c.Abort()

--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -64,16 +64,14 @@ func GetChainMiddleware(chainNameParamKey string) gin.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot retrieve chain with name %v", chainName),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve chain",
 				"name",
 				chainName,
 				"error",
 				err,
 			)
-
+			c.Error(e)
 			c.Abort()
 			return
 		}

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -51,13 +51,12 @@ func GetChains(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve chains"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chains",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -130,9 +129,7 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 			"primarychannel",
 			fmt.Errorf("cannot retrieve primary channel between %v and %v", chainName, counterparty),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
@@ -141,6 +138,7 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -174,15 +172,14 @@ func GetPrimaryChannels(c *gin.Context) {
 			"primarychannel",
 			fmt.Errorf("cannot retrieve primary channels for %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -282,9 +279,7 @@ func VerifyTrace(c *gin.Context) {
 			"denom/verify-trace",
 			fmt.Errorf("cannot query list of chain ids"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query list of chain ids",
 			"hash",
 			hash,
@@ -293,6 +288,7 @@ func VerifyTrace(c *gin.Context) {
 			"err",
 			err,
 		)
+		c.Error(e)
 		return
 	}
 
@@ -419,9 +415,7 @@ func VerifyTrace(c *gin.Context) {
 			"denom/verify-trace",
 			fmt.Errorf("database error, %w", err),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			fmt.Sprintf("cannot query chain with name %s", nextChain),
 			"hash",
 			hash,
@@ -434,6 +428,7 @@ func VerifyTrace(c *gin.Context) {
 			"err",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -444,9 +439,7 @@ func VerifyTrace(c *gin.Context) {
 			"denom/verify-trace",
 			fmt.Errorf("cannot retrieve chain status for %v", nextChain),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain last block time",
 			"hash",
 			hash,
@@ -459,6 +452,7 @@ func VerifyTrace(c *gin.Context) {
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -565,8 +559,6 @@ func GetChainStatus(c *gin.Context) {
 // @Failure 500,403 {object} deps.Error
 // @Router /chain/{chainName}/supply [get]
 func GetChainSupply(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	paginationKey, exists := c.GetQuery("key")
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
@@ -575,15 +567,14 @@ func GetChainSupply(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -602,15 +593,14 @@ func GetChainSupply(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve supply from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve supply from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -649,8 +639,6 @@ func GetChainSupply(c *gin.Context) {
 // @Failure 400 {object} deps.Error
 // @Router /chain/{chainName}/supply/:denom [get]
 func GetDenomSupply(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	denom := c.Param("denom")
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 
@@ -660,13 +648,12 @@ func GetDenomSupply(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name", chain.ChainName,
 			"error", err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -686,14 +673,13 @@ func GetDenomSupply(c *gin.Context) {
 			"chains",
 			cause,
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve denom supply from sdk-service",
 			"chain name", chain.ChainName,
 			"denom name", denom,
 			"error", err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -714,8 +700,6 @@ func GetDenomSupply(c *gin.Context) {
 // @Failure 500,403 {object} deps.Error
 // @Router /chain/{chainName}/txs/{txhash} [get]
 func GetChainTx(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	txHash := c.Param("tx")
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
@@ -724,15 +708,14 @@ func GetChainTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -747,15 +730,14 @@ func GetChainTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve tx from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -774,8 +756,6 @@ func GetChainTx(c *gin.Context) {
 // @Failure 500,403 {object} deps.Error
 // @Router /chain/{chainName}/numbers/{address} [get]
 func GetNumbersByAddress(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	address := c.Param("address")
 	chainInfo := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 
@@ -785,9 +765,7 @@ func GetNumbersByAddress(c *gin.Context) {
 			"numbers",
 			fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query nodes auth for address",
 			"address",
 			address,
@@ -796,6 +774,7 @@ func GetNumbersByAddress(c *gin.Context) {
 			"chain",
 			chainInfo,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -813,8 +792,6 @@ func GetNumbersByAddress(c *gin.Context) {
 // @Failure 500,403 {object} deps.Error
 // @Router /chain/{chainName}/mint/inflation [get]
 func GetInflation(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
@@ -823,15 +800,14 @@ func GetInflation(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -845,15 +821,14 @@ func GetInflation(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve inflation from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve inflation from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -871,8 +846,6 @@ func GetInflation(c *gin.Context) {
 // @Failure 400 {object} deps.Error
 // @Router /chain/{chainName}/staking/params [get]
 func GetStakingParams(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
@@ -881,15 +854,14 @@ func GetStakingParams(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -903,15 +875,14 @@ func GetStakingParams(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve staking params from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve staking params from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -929,8 +900,6 @@ func GetStakingParams(c *gin.Context) {
 // @Failure 400 {object} deps.Error
 // @Router /chain/{chainName}/staking/pool [get]
 func GetStakingPool(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
@@ -939,15 +908,14 @@ func GetStakingPool(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -961,15 +929,14 @@ func GetStakingPool(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve staking pool from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve staking pool from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -987,8 +954,6 @@ func GetStakingPool(c *gin.Context) {
 // @Failure 500,403 {object} deps.Error
 // @Router /chain/{chainName}/mint/params [get]
 func GetMintParams(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
@@ -996,15 +961,14 @@ func GetMintParams(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1018,15 +982,14 @@ func GetMintParams(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve mint params from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve mint params from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1044,8 +1007,6 @@ func GetMintParams(c *gin.Context) {
 // @Failure 500,403 {object} deps.Error
 // @Router /chain/{chainName}/mint/annual_provisions [get]
 func GetAnnualProvisions(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
 	if err != nil {
@@ -1053,15 +1014,14 @@ func GetAnnualProvisions(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1075,15 +1035,14 @@ func GetAnnualProvisions(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve mint annual provision from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve mint annual provision from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1101,8 +1060,6 @@ func GetAnnualProvisions(c *gin.Context) {
 // @Failure 400 {object} deps.Error
 // @Router /chain/{chainName}/mint/epoch_provisions [get]
 func GetEpochProvisions(c *gin.Context) {
-	d := deps.GetDeps(c)
-
 	chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 
 	client, err := sdkservice.Client(chain.MajorSDKVersion())
@@ -1111,15 +1068,14 @@ func GetEpochProvisions(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1133,15 +1089,14 @@ func GetEpochProvisions(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve mint epoch provisions from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve mint epoch provisions from sdk-service",
 			"name",
 			chain.ChainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1176,15 +1131,14 @@ func GetStakingAPR(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot get APR"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot get APR",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1195,9 +1149,7 @@ func GetStakingAPR(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot convert apr to float"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot convert apr to float",
 			"name",
 			chainName,
@@ -1206,6 +1158,7 @@ func GetStakingAPR(c *gin.Context) {
 			"APR",
 			apr,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -1215,8 +1168,6 @@ func GetStakingAPR(c *gin.Context) {
 
 func getAPR(c *gin.Context) stringcache.HandlerFunc {
 	return func(ctx context.Context, key string) (string, error) {
-		d := deps.GetDeps(c)
-
 		chain := ginutils.GetValue[cns.Chain](c, ChainContextKey)
 		client, err := sdkservice.Client(chain.MajorSDKVersion())
 		if err != nil {
@@ -1224,15 +1175,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve chain's sdk-service",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1247,15 +1197,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot retrieve staking pool from sdk-service"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve staking pool from sdk-service",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1267,15 +1216,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot unmarshal staking pool"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot unmarshal staking pool",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1286,15 +1234,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot convert bonded_tokens to sdktypes.Dec"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot convert bonded_tokens to sdktypes.Dec",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1309,15 +1256,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot retrieve staking params from sdk-service"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve staking params from sdk-service",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1329,15 +1275,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot unmarshal staking params"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot unmarshal staking params",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1360,14 +1305,13 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				cause,
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve denom supply from sdk-service",
 				"chain name", chain.ChainName,
 				"denom name", bond_denom,
 				"error", err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1380,15 +1324,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot convert amount to coin"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot convert amount to coin",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1405,15 +1348,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot retrieve inflation from sdk-service"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve inflation from sdk-service",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1425,15 +1367,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot unmarshal inflation"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot unmarshal inflation",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}
@@ -1444,15 +1385,14 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chains",
 				fmt.Errorf("cannot convert inflation to sdktypes.Dec"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot convert inflation to sdktypes.Dec",
 				"name",
 				chain.ChainName,
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return "", err
 		}

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -49,7 +49,7 @@ func GetChains(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve chains"),
+			fmt.Sprintf("cannot retrieve chains"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chains",
@@ -127,7 +127,7 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"primarychannel",
-			fmt.Errorf("cannot retrieve primary channel between %v and %v", chainName, counterparty),
+			fmt.Sprintf("cannot retrieve primary channel between %v and %v", chainName, counterparty),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -170,7 +170,7 @@ func GetPrimaryChannels(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"primarychannel",
-			fmt.Errorf("cannot retrieve primary channels for %v", chainName),
+			fmt.Sprintf("cannot retrieve primary channels for %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -277,7 +277,7 @@ func VerifyTrace(c *gin.Context) {
 
 		e := apierrors.New(
 			"denom/verify-trace",
-			fmt.Errorf("cannot query list of chain ids"),
+			fmt.Sprintf("cannot query list of chain ids"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query list of chain ids",
@@ -363,7 +363,7 @@ func VerifyTrace(c *gin.Context) {
 			} else {
 				e1 := apierrors.New(
 					"denom/verify-trace",
-					fmt.Errorf("failed querying for %s, error: %w", hash, err),
+					fmt.Sprintf("failed querying for %s, error: %w", hash, err),
 					http.StatusBadRequest,
 				)
 
@@ -413,7 +413,7 @@ func VerifyTrace(c *gin.Context) {
 
 		e := apierrors.New(
 			"denom/verify-trace",
-			fmt.Errorf("database error, %w", err),
+			fmt.Sprintf("database error, %w", err),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			fmt.Sprintf("cannot query chain with name %s", nextChain),
@@ -437,7 +437,7 @@ func VerifyTrace(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"denom/verify-trace",
-			fmt.Errorf("cannot retrieve chain status for %v", nextChain),
+			fmt.Sprintf("cannot retrieve chain status for %v", nextChain),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot retrieve chain last block time",
@@ -565,7 +565,7 @@ func GetChainSupply(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -591,7 +591,7 @@ func GetChainSupply(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve supply from sdk-service"),
+			fmt.Sprintf("cannot retrieve supply from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve supply from sdk-service",
@@ -646,7 +646,7 @@ func GetDenomSupply(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -665,9 +665,9 @@ func GetDenomSupply(c *gin.Context) {
 
 	sdkRes, err := client.SupplyDenom(context.Background(), payload)
 	if err != nil || len(sdkRes.Coins) != 1 { // Expected exactly one response
-		cause := fmt.Errorf("cannot retrieve supply for chain: %s - denom: %s from sdk-service", chain.ChainName, denom)
+		cause := fmt.Sprintf("cannot retrieve supply for chain: %s - denom: %s from sdk-service", chain.ChainName, denom)
 		if sdkRes != nil && len(sdkRes.Coins) != 1 {
-			cause = fmt.Errorf("expected 1 denom for chain: %s - denom: %s, found %v", chain.ChainName, denom, sdkRes.Coins)
+			cause = fmt.Sprintf("expected 1 denom for chain: %s - denom: %s, found %v", chain.ChainName, denom, sdkRes.Coins)
 		}
 		e := apierrors.New(
 			"chains",
@@ -706,7 +706,7 @@ func GetChainTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -728,7 +728,7 @@ func GetChainTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve tx from sdk-service, %w", err),
+			fmt.Sprintf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve tx from sdk-service",
@@ -763,7 +763,7 @@ func GetNumbersByAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"numbers",
-			fmt.Errorf("cannot retrieve account/sequence numbers for address %v", address),
+			fmt.Sprintf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot query nodes auth for address",
@@ -798,7 +798,7 @@ func GetInflation(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -819,7 +819,7 @@ func GetInflation(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve inflation from sdk-service"),
+			fmt.Sprintf("cannot retrieve inflation from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve inflation from sdk-service",
@@ -852,7 +852,7 @@ func GetStakingParams(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -873,7 +873,7 @@ func GetStakingParams(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve staking params from sdk-service"),
+			fmt.Sprintf("cannot retrieve staking params from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve staking params from sdk-service",
@@ -906,7 +906,7 @@ func GetStakingPool(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -927,7 +927,7 @@ func GetStakingPool(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve staking pool from sdk-service"),
+			fmt.Sprintf("cannot retrieve staking pool from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve staking pool from sdk-service",
@@ -959,7 +959,7 @@ func GetMintParams(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -980,7 +980,7 @@ func GetMintParams(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve mint params from sdk-service"),
+			fmt.Sprintf("cannot retrieve mint params from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve mint params from sdk-service",
@@ -1012,7 +1012,7 @@ func GetAnnualProvisions(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -1033,7 +1033,7 @@ func GetAnnualProvisions(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve mint annual provision from sdk-service"),
+			fmt.Sprintf("cannot retrieve mint annual provision from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve mint annual provision from sdk-service",
@@ -1066,7 +1066,7 @@ func GetEpochProvisions(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -1087,7 +1087,7 @@ func GetEpochProvisions(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve mint epoch provisions from sdk-service"),
+			fmt.Sprintf("cannot retrieve mint epoch provisions from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve mint epoch provisions from sdk-service",
@@ -1129,7 +1129,7 @@ func GetStakingAPR(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot get APR"),
+			fmt.Sprintf("cannot get APR"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot get APR",
@@ -1147,7 +1147,7 @@ func GetStakingAPR(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot convert apr to float"),
+			fmt.Sprintf("cannot convert apr to float"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot convert apr to float",
@@ -1173,7 +1173,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+				fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot retrieve chain's sdk-service",
@@ -1195,7 +1195,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot retrieve staking pool from sdk-service"),
+				fmt.Sprintf("cannot retrieve staking pool from sdk-service"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot retrieve staking pool from sdk-service",
@@ -1214,7 +1214,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot unmarshal staking pool"),
+				fmt.Sprintf("cannot unmarshal staking pool"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot unmarshal staking pool",
@@ -1232,7 +1232,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot convert bonded_tokens to sdktypes.Dec"),
+				fmt.Sprintf("cannot convert bonded_tokens to sdktypes.Dec"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot convert bonded_tokens to sdktypes.Dec",
@@ -1254,7 +1254,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot retrieve staking params from sdk-service"),
+				fmt.Sprintf("cannot retrieve staking params from sdk-service"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot retrieve staking params from sdk-service",
@@ -1273,7 +1273,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot unmarshal staking params"),
+				fmt.Sprintf("cannot unmarshal staking params"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot unmarshal staking params",
@@ -1297,9 +1297,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 
 		denomSupplyRes, err := client.SupplyDenom(context.Background(), payload)
 		if err != nil || len(denomSupplyRes.Coins) != 1 { // Expected exactly one response
-			cause := fmt.Errorf("cannot retrieve supply for chain: %s - denom: %s from sdk-service", chain.ChainName, bond_denom)
+			cause := fmt.Sprintf("cannot retrieve supply for chain: %s - denom: %s from sdk-service", chain.ChainName, bond_denom)
 			if denomSupplyRes != nil && len(denomSupplyRes.Coins) != 1 {
-				cause = fmt.Errorf("expected 1 denom for chain: %s - denom: %s, found %v", chain.ChainName, bond_denom, denomSupplyRes.Coins)
+				cause = fmt.Sprintf("expected 1 denom for chain: %s - denom: %s, found %v", chain.ChainName, bond_denom, denomSupplyRes.Coins)
 			}
 			e := apierrors.New(
 				"chains",
@@ -1322,7 +1322,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot convert amount to coin"),
+				fmt.Sprintf("cannot convert amount to coin"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot convert amount to coin",
@@ -1346,7 +1346,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot retrieve inflation from sdk-service"),
+				fmt.Sprintf("cannot retrieve inflation from sdk-service"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot retrieve inflation from sdk-service",
@@ -1365,7 +1365,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot unmarshal inflation"),
+				fmt.Sprintf("cannot unmarshal inflation"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot unmarshal inflation",
@@ -1383,7 +1383,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		if err != nil {
 			e := apierrors.New(
 				"chains",
-				fmt.Errorf("cannot convert inflation to sdktypes.Dec"),
+				fmt.Sprintf("cannot convert inflation to sdktypes.Dec"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot convert inflation to sdktypes.Dec",

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -52,9 +52,7 @@ func GetChains(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chains"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chains",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve chains: %w", err),
 		)
 		c.Error(e)
 
@@ -130,13 +128,11 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve primary channel between %v and %v", chainName, counterparty),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
 			"counterparty",
 			counterparty,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -173,11 +169,9 @@ func GetPrimaryChannels(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve primary channels for %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -229,8 +223,6 @@ func VerifyTrace(c *gin.Context) {
 			hash,
 			"chainName",
 			chainName,
-			"error",
-			err,
 		)
 
 		res.VerifiedTrace.Verified = false
@@ -280,13 +272,11 @@ func VerifyTrace(c *gin.Context) {
 			fmt.Sprintf("cannot query list of chain ids"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query list of chain ids",
+			fmt.Errorf("cannot query list of chain ids: %w", err),
 			"hash",
 			hash,
 			"path",
 			res.VerifiedTrace.Path,
-			"err",
-			err,
 		)
 		c.Error(e)
 		return
@@ -416,7 +406,7 @@ func VerifyTrace(c *gin.Context) {
 			fmt.Sprintf("database error, %w", err),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			fmt.Sprintf("cannot query chain with name %s", nextChain),
+			fmt.Errorf("cannot query chain with name: %w", err),
 			"hash",
 			hash,
 			"path",
@@ -425,8 +415,6 @@ func VerifyTrace(c *gin.Context) {
 			chainName,
 			"nextChain",
 			nextChain,
-			"err",
-			err,
 		)
 		c.Error(e)
 
@@ -440,7 +428,7 @@ func VerifyTrace(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain status for %v", nextChain),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot retrieve chain last block time",
+			fmt.Errorf("cannot retrieve chain last block time: %w", err),
 			"hash",
 			hash,
 			"path",
@@ -449,8 +437,6 @@ func VerifyTrace(c *gin.Context) {
 			chainName,
 			"nextChain",
 			nextChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -568,11 +554,9 @@ func GetChainSupply(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -594,11 +578,9 @@ func GetChainSupply(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve supply from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve supply from sdk-service",
+			fmt.Errorf("cannot retrieve supply from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -649,9 +631,8 @@ func GetDenomSupply(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name", chain.ChainName,
-			"error", err,
 		)
 		c.Error(e)
 
@@ -674,10 +655,9 @@ func GetDenomSupply(c *gin.Context) {
 			cause,
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve denom supply from sdk-service",
+			fmt.Errorf("cannot retrieve denom supply from sdk-service: %w", err),
 			"chain name", chain.ChainName,
 			"denom name", denom,
-			"error", err,
 		)
 		c.Error(e)
 
@@ -709,11 +689,9 @@ func GetChainTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -731,11 +709,9 @@ func GetChainTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve tx from sdk-service",
+			fmt.Errorf("cannot retrieve tx from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -766,11 +742,9 @@ func GetNumbersByAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve account/sequence numbers for address %v", address),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot query nodes auth for address",
+			fmt.Errorf("cannot query nodes auth for address: %w", err),
 			"address",
 			address,
-			"error",
-			err,
 			"chain",
 			chainInfo,
 		)
@@ -801,11 +775,9 @@ func GetInflation(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -822,11 +794,9 @@ func GetInflation(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve inflation from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve inflation from sdk-service",
+			fmt.Errorf("cannot retrieve inflation from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -855,11 +825,9 @@ func GetStakingParams(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -876,11 +844,9 @@ func GetStakingParams(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve staking params from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve staking params from sdk-service",
+			fmt.Errorf("cannot retrieve staking params from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -909,11 +875,9 @@ func GetStakingPool(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -930,11 +894,9 @@ func GetStakingPool(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve staking pool from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve staking pool from sdk-service",
+			fmt.Errorf("cannot retrieve staking pool from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -962,11 +924,9 @@ func GetMintParams(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -983,11 +943,9 @@ func GetMintParams(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve mint params from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve mint params from sdk-service",
+			fmt.Errorf("cannot retrieve mint params from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -1015,11 +973,9 @@ func GetAnnualProvisions(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -1036,11 +992,9 @@ func GetAnnualProvisions(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve mint annual provision from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve mint annual provision from sdk-service",
+			fmt.Errorf("cannot retrieve mint annual provision from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -1069,11 +1023,9 @@ func GetEpochProvisions(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -1090,11 +1042,9 @@ func GetEpochProvisions(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve mint epoch provisions from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve mint epoch provisions from sdk-service",
+			fmt.Errorf("cannot retrieve mint epoch provisions from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -1132,11 +1082,9 @@ func GetStakingAPR(c *gin.Context) {
 			fmt.Sprintf("cannot get APR"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot get APR",
+			fmt.Errorf("cannot get APR: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -1150,11 +1098,9 @@ func GetStakingAPR(c *gin.Context) {
 			fmt.Sprintf("cannot convert apr to float"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot convert apr to float",
+			fmt.Errorf("cannot convert apr to float: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 			"APR",
 			apr,
 		)
@@ -1176,11 +1122,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve chain's sdk-service",
+				fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1198,11 +1142,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot retrieve staking pool from sdk-service"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve staking pool from sdk-service",
+				fmt.Errorf("cannot retrieve staking pool from sdk-service: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1217,11 +1159,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot unmarshal staking pool"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot unmarshal staking pool",
+				fmt.Errorf("cannot unmarshal staking pool: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1235,11 +1175,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot convert bonded_tokens to sdktypes.Dec"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot convert bonded_tokens to sdktypes.Dec",
+				fmt.Errorf("cannot convert bonded_tokens to sdktypes.Dec: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1257,11 +1195,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot retrieve staking params from sdk-service"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve staking params from sdk-service",
+				fmt.Errorf("cannot retrieve staking params from sdk-service: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1276,11 +1212,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot unmarshal staking params"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot unmarshal staking params",
+				fmt.Errorf("cannot unmarshal staking params: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1306,10 +1240,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				cause,
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve denom supply from sdk-service",
+				fmt.Errorf("cannot retrieve denom supply from sdk-service: %w", err),
 				"chain name", chain.ChainName,
 				"denom name", bond_denom,
-				"error", err,
 			)
 			c.Error(e)
 
@@ -1325,11 +1258,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot convert amount to coin"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot convert amount to coin",
+				fmt.Errorf("cannot convert amount to coin: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1349,11 +1280,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot retrieve inflation from sdk-service"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve inflation from sdk-service",
+				fmt.Errorf("cannot retrieve inflation from sdk-service: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1368,11 +1297,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot unmarshal inflation"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot unmarshal inflation",
+				fmt.Errorf("cannot unmarshal inflation: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 
@@ -1386,11 +1313,9 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				fmt.Sprintf("cannot convert inflation to sdktypes.Dec"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot convert inflation to sdktypes.Dec",
+				fmt.Errorf("cannot convert inflation to sdktypes.Dec: %w", err),
 				"name",
 				chain.ChainName,
-				"error",
-				err,
 			)
 			c.Error(e)
 

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -54,7 +54,7 @@ func GetChains(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve chains: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -134,7 +134,7 @@ func GetPrimaryChannelWithCounterparty(c *gin.Context) {
 			"counterparty",
 			counterparty,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -173,7 +173,7 @@ func GetPrimaryChannels(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -278,7 +278,7 @@ func VerifyTrace(c *gin.Context) {
 			"path",
 			res.VerifiedTrace.Path,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 
@@ -353,15 +353,14 @@ func VerifyTrace(c *gin.Context) {
 			} else {
 				e1 := apierrors.New(
 					"denom/verify-trace",
-					fmt.Sprintf("failed querying for %s, error: %w", hash, err),
+					fmt.Sprintf("failed querying for %s, error: %v", hash, err),
 					http.StatusBadRequest,
-				)
-
-				d.WriteError(c, e1,
-					"invalid number of query responses",
+				).WithLogContext(
+					fmt.Errorf("invalid number of query responses: %w", err),
 					"hash",
 					hash,
 				)
+				_ = c.Error(e1)
 			}
 
 			return
@@ -403,7 +402,7 @@ func VerifyTrace(c *gin.Context) {
 
 		e := apierrors.New(
 			"denom/verify-trace",
-			fmt.Sprintf("database error, %w", err),
+			fmt.Sprintf("database error, %v", err),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			fmt.Errorf("cannot query chain with name: %w", err),
@@ -416,7 +415,7 @@ func VerifyTrace(c *gin.Context) {
 			"nextChain",
 			nextChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -438,7 +437,7 @@ func VerifyTrace(c *gin.Context) {
 			"nextChain",
 			nextChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -558,7 +557,7 @@ func GetChainSupply(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -582,7 +581,7 @@ func GetChainSupply(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -634,7 +633,7 @@ func GetDenomSupply(c *gin.Context) {
 			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name", chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -659,7 +658,7 @@ func GetDenomSupply(c *gin.Context) {
 			"chain name", chain.ChainName,
 			"denom name", denom,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -693,7 +692,7 @@ func GetChainTx(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -706,14 +705,14 @@ func GetChainTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Sprintf("cannot retrieve tx from sdk-service, %w", err),
+			fmt.Sprintf("cannot retrieve tx from sdk-service, %v", err),
 			http.StatusBadRequest,
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve tx from sdk-service: %w", err),
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -748,7 +747,7 @@ func GetNumbersByAddress(c *gin.Context) {
 			"chain",
 			chainInfo,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -779,7 +778,7 @@ func GetInflation(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -798,7 +797,7 @@ func GetInflation(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -829,7 +828,7 @@ func GetStakingParams(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -848,7 +847,7 @@ func GetStakingParams(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -879,7 +878,7 @@ func GetStakingPool(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -898,7 +897,7 @@ func GetStakingPool(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -928,7 +927,7 @@ func GetMintParams(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -947,7 +946,7 @@ func GetMintParams(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -977,7 +976,7 @@ func GetAnnualProvisions(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -996,7 +995,7 @@ func GetAnnualProvisions(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -1027,7 +1026,7 @@ func GetEpochProvisions(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -1046,7 +1045,7 @@ func GetEpochProvisions(c *gin.Context) {
 			"name",
 			chain.ChainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -1086,7 +1085,7 @@ func GetStakingAPR(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -1104,7 +1103,7 @@ func GetStakingAPR(c *gin.Context) {
 			"APR",
 			apr,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -1126,7 +1125,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1146,7 +1145,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1163,7 +1162,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1179,7 +1178,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1199,7 +1198,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1216,7 +1215,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1244,7 +1243,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"chain name", chain.ChainName,
 				"denom name", bond_denom,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1262,7 +1261,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1284,7 +1283,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1301,7 +1300,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}
@@ -1317,7 +1316,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 				"name",
 				chain.ChainName,
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return "", err
 		}

--- a/api/chains/fee.go
+++ b/api/chains/fee.go
@@ -34,11 +34,9 @@ func GetFee(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -77,11 +75,9 @@ func GetFeeAddress(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -117,9 +113,7 @@ func GetFeeAddresses(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chains"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chains",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve chains: %w", err),
 		)
 		c.Error(e)
 
@@ -164,11 +158,9 @@ func GetFeeToken(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 

--- a/api/chains/fee.go
+++ b/api/chains/fee.go
@@ -31,7 +31,7 @@ func GetFee(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"fee",
-			fmt.Errorf("cannot retrieve chain with name %v", chainName),
+			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -74,7 +74,7 @@ func GetFeeAddress(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"feeaddress",
-			fmt.Errorf("cannot retrieve chain with name %v", chainName),
+			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -114,7 +114,7 @@ func GetFeeAddresses(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"feeaddress",
-			fmt.Errorf("cannot retrieve chains"),
+			fmt.Sprintf("cannot retrieve chains"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chains",
@@ -161,7 +161,7 @@ func GetFeeToken(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"feetoken",
-			fmt.Errorf("cannot retrieve chain with name %v", chainName),
+			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",

--- a/api/chains/fee.go
+++ b/api/chains/fee.go
@@ -38,7 +38,7 @@ func GetFee(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -79,7 +79,7 @@ func GetFeeAddress(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -115,7 +115,7 @@ func GetFeeAddresses(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve chains: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -162,7 +162,7 @@ func GetFeeToken(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/chains/fee.go
+++ b/api/chains/fee.go
@@ -33,15 +33,14 @@ func GetFee(c *gin.Context) {
 			"fee",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -77,15 +76,14 @@ func GetFeeAddress(c *gin.Context) {
 			"feeaddress",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -118,13 +116,12 @@ func GetFeeAddresses(c *gin.Context) {
 			"feeaddress",
 			fmt.Errorf("cannot retrieve chains"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chains",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -166,15 +163,14 @@ func GetFeeToken(c *gin.Context) {
 			"feetoken",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/chains/validators.go
+++ b/api/chains/validators.go
@@ -39,15 +39,14 @@ func GetValidators(c *gin.Context) {
 			"validators",
 			fmt.Errorf("cannot retrieve validators"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve validators",
 			"error",
 			err,
 			"chain",
 			chainName,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/chains/validators.go
+++ b/api/chains/validators.go
@@ -37,7 +37,7 @@ func GetValidators(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"validators",
-			fmt.Errorf("cannot retrieve validators"),
+			fmt.Sprintf("cannot retrieve validators"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve validators",

--- a/api/chains/validators.go
+++ b/api/chains/validators.go
@@ -44,7 +44,7 @@ func GetValidators(c *gin.Context) {
 			"chain",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/chains/validators.go
+++ b/api/chains/validators.go
@@ -40,9 +40,7 @@ func GetValidators(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve validators"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve validators",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve validators: %w", err),
 			"chain",
 			chainName,
 		)

--- a/api/liquidity/api.go
+++ b/api/liquidity/api.go
@@ -38,15 +38,14 @@ func getSwapFee(c *gin.Context) {
 			"swap fees",
 			fmt.Errorf("cannot get swap fees"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot get swap fees",
 			"poolId",
 			poolId,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/liquidity/api.go
+++ b/api/liquidity/api.go
@@ -36,7 +36,7 @@ func getSwapFee(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"swap fees",
-			fmt.Errorf("cannot get swap fees"),
+			fmt.Sprintf("cannot get swap fees"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot get swap fees",

--- a/api/liquidity/api.go
+++ b/api/liquidity/api.go
@@ -39,11 +39,9 @@ func getSwapFee(c *gin.Context) {
 			fmt.Sprintf("cannot get swap fees"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot get swap fees",
+			fmt.Errorf("cannot get swap fees: %w", err),
 			"poolId",
 			poolId,
-			"error",
-			err,
 		)
 		c.Error(e)
 

--- a/api/liquidity/api.go
+++ b/api/liquidity/api.go
@@ -43,7 +43,7 @@ func getSwapFee(c *gin.Context) {
 			"poolId",
 			poolId,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/relayer/api.go
+++ b/api/relayer/api.go
@@ -53,9 +53,7 @@ func getRelayerStatus(c *gin.Context) {
 			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot query relayer status",
-			"error",
-			err,
+			fmt.Errorf("cannot query relayer status: %w", err),
 			"obj",
 			obj,
 		)
@@ -71,9 +69,7 @@ func getRelayerStatus(c *gin.Context) {
 			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot unstructure relayer status",
-			"error",
-			err,
+			fmt.Errorf("cannot unstructure relayer status: %w", err),
 		)
 		c.Error(e)
 
@@ -114,9 +110,7 @@ func getRelayerBalance(c *gin.Context) {
 			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot query relayer status",
-			"error",
-			err,
+			fmt.Errorf("cannot query relayer status: %w", err),
 			"obj",
 			obj,
 		)
@@ -132,9 +126,7 @@ func getRelayerBalance(c *gin.Context) {
 			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot unstructure relayer status",
-			"error",
-			err,
+			fmt.Errorf("cannot unstructure relayer status: %w", err),
 		)
 		c.Error(e)
 		return
@@ -155,9 +147,7 @@ func getRelayerBalance(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve relayer status"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve relayer status",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve relayer status: %w", err),
 		)
 		c.Error(e)
 
@@ -177,9 +167,7 @@ func getRelayerBalance(c *gin.Context) {
 				fmt.Sprintf("cannot retrieve relayer status"),
 				http.StatusBadRequest,
 			).WithLogContext(
-				"cannot retrieve relayer status",
-				"error",
-				err,
+				fmt.Errorf("cannot retrieve relayer status: %w", err),
 			)
 			c.Error(e)
 

--- a/api/relayer/api.go
+++ b/api/relayer/api.go
@@ -52,15 +52,14 @@ func getRelayerStatus(c *gin.Context) {
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query relayer status",
 			"error",
 			err,
 			"obj",
 			obj,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -71,13 +70,12 @@ func getRelayerStatus(c *gin.Context) {
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot unstructure relayer status",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -115,15 +113,14 @@ func getRelayerBalance(c *gin.Context) {
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot query relayer status",
 			"error",
 			err,
 			"obj",
 			obj,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -134,14 +131,13 @@ func getRelayerBalance(c *gin.Context) {
 			"status",
 			fmt.Errorf("cannot query relayer status"),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot unstructure relayer status",
 			"error",
 			err,
 		)
-
+		c.Error(e)
+		return
 	}
 
 	chains := []string{}
@@ -158,13 +154,12 @@ func getRelayerBalance(c *gin.Context) {
 			"status",
 			fmt.Errorf("cannot retrieve relayer status"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve relayer status",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -181,13 +176,12 @@ func getRelayerBalance(c *gin.Context) {
 				"status",
 				fmt.Errorf("cannot retrieve relayer status"),
 				http.StatusBadRequest,
-			)
-
-			d.WriteError(c, e,
+			).WithLogContext(
 				"cannot retrieve relayer status",
 				"error",
 				err,
 			)
+			c.Error(e)
 
 			return
 		}

--- a/api/relayer/api.go
+++ b/api/relayer/api.go
@@ -57,7 +57,7 @@ func getRelayerStatus(c *gin.Context) {
 			"obj",
 			obj,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -71,7 +71,7 @@ func getRelayerStatus(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot unstructure relayer status: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -114,7 +114,7 @@ func getRelayerBalance(c *gin.Context) {
 			"obj",
 			obj,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -128,7 +128,7 @@ func getRelayerBalance(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot unstructure relayer status: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 		return
 	}
 
@@ -149,7 +149,7 @@ func getRelayerBalance(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve relayer status: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -169,7 +169,7 @@ func getRelayerBalance(c *gin.Context) {
 			).WithLogContext(
 				fmt.Errorf("cannot retrieve relayer status: %w", err),
 			)
-			c.Error(e)
+			_ = c.Error(e)
 
 			return
 		}

--- a/api/relayer/api.go
+++ b/api/relayer/api.go
@@ -50,7 +50,7 @@ func getRelayerStatus(c *gin.Context) {
 	if err != nil && !errors.Is(err, k8s.ErrNotFound) {
 		e := apierrors.New(
 			"status",
-			fmt.Errorf("cannot query relayer status"),
+			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot query relayer status",
@@ -68,7 +68,7 @@ func getRelayerStatus(c *gin.Context) {
 	if err != nil && !errors.Is(err, k8s.ErrNotFound) {
 		e := apierrors.New(
 			"status",
-			fmt.Errorf("cannot query relayer status"),
+			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot unstructure relayer status",
@@ -111,7 +111,7 @@ func getRelayerBalance(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"status",
-			fmt.Errorf("cannot query relayer status"),
+			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot query relayer status",
@@ -129,7 +129,7 @@ func getRelayerBalance(c *gin.Context) {
 	if err != nil && !errors.Is(err, k8s.ErrNotFound) {
 		e := apierrors.New(
 			"status",
-			fmt.Errorf("cannot query relayer status"),
+			fmt.Sprintf("cannot query relayer status"),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot unstructure relayer status",
@@ -152,7 +152,7 @@ func getRelayerBalance(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"status",
-			fmt.Errorf("cannot retrieve relayer status"),
+			fmt.Sprintf("cannot retrieve relayer status"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve relayer status",
@@ -174,7 +174,7 @@ func getRelayerBalance(c *gin.Context) {
 		if err != nil {
 			e := apierrors.New(
 				"status",
-				fmt.Errorf("cannot retrieve relayer status"),
+				fmt.Sprintf("cannot retrieve relayer status"),
 				http.StatusBadRequest,
 			).WithLogContext(
 				"cannot retrieve relayer status",

--- a/api/router/deps/deps.go
+++ b/api/router/deps/deps.go
@@ -38,7 +38,7 @@ func GetDeps(c *gin.Context) *Deps {
 }
 
 // WriteError adds an error to the gin context and logs it.
-func (d *Deps) WriteError(c *gin.Context, err apierrors.Error, logMessage string, keyAndValues ...interface{}) {
+func (d *Deps) WriteError(c *gin.Context, err *apierrors.Error, logMessage string, keyAndValues ...interface{}) {
 	_ = c.Error(err)
 
 	if keyAndValues != nil {

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -144,6 +144,15 @@ func (r *Router) handleErrors(c *gin.Context) {
 		panic(fmt.Sprintf("expected to receive error of type *apierrors.Errors, got %T with content: %v", l, l))
 	}
 
+	if len(err.InternalCause) > 0 {
+		keysAndValues := append(err.LogKeysAndValues, "error", err)
+		d := deps.GetDeps(c)
+		d.Logger.Errorw(
+			err.InternalCause,
+			keysAndValues...,
+		)
+	}
+
 	id := tryGetIntCorrelationID(c)
 	userError := apierrors.NewUserFacingError(id, err)
 	c.JSON(err.StatusCode, userError)

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -144,14 +144,12 @@ func (r *Router) handleErrors(c *gin.Context) {
 		panic(fmt.Sprintf("expected to receive error of type *apierrors.Errors, got %T with content: %v", l, l))
 	}
 
-	if len(err.InternalCause.Error()) > 0 {
-		keysAndValues := append(err.LogKeysAndValues, "error", err)
-		d := deps.GetDeps(c)
-		d.Logger.Errorw(
-			err.InternalCause.Error(),
-			keysAndValues...,
-		)
-	}
+	keysAndValues := append(err.LogKeysAndValues, "error", err)
+	d := deps.GetDeps(c)
+	d.Logger.Errorw(
+		err.Error(),
+		keysAndValues...,
+	)
 
 	id := tryGetIntCorrelationID(c)
 	userError := apierrors.NewUserFacingError(id, err)

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -139,9 +139,9 @@ func (r *Router) handleErrors(c *gin.Context) {
 		return
 	}
 
-	err := apierrors.Error{}
+	err := &apierrors.Error{}
 	if !errors.As(l, &err) {
-		panic(l)
+		panic(fmt.Sprintf("expected to receive error of type *apierrors.Errors, got %T with content: %v", l, l))
 	}
 
 	id := tryGetIntCorrelationID(c)

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -144,11 +144,11 @@ func (r *Router) handleErrors(c *gin.Context) {
 		panic(fmt.Sprintf("expected to receive error of type *apierrors.Errors, got %T with content: %v", l, l))
 	}
 
-	if len(err.InternalCause) > 0 {
+	if len(err.InternalCause.Error()) > 0 {
 		keysAndValues := append(err.LogKeysAndValues, "error", err)
 		d := deps.GetDeps(c)
 		d.Logger.Errorw(
-			err.InternalCause,
+			err.InternalCause.Error(),
 			keysAndValues...,
 		)
 	}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -97,7 +97,7 @@ func (r *Router) catchPanicsFunc(c *gin.Context) {
 			// okay we panic-ed, log it through r's logger and write back internal server error
 			err := apierrors.New(
 				"fatal_error",
-				errors.New("internal server error"),
+				fmt.Sprintf("internal server error"),
 				http.StatusInternalServerError)
 
 			logger := logging.AddCorrelationIDToLogger(c, r.l)

--- a/api/tx/api.go
+++ b/api/tx/api.go
@@ -41,13 +41,12 @@ func Tx(c *gin.Context) {
 	err := c.BindJSON(&txRequest)
 
 	if err != nil {
-		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest)
-
-		d.WriteError(c, e,
+		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
 			"Failed to parse JSON",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -58,15 +57,14 @@ func Tx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -77,15 +75,14 @@ func Tx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -93,13 +90,12 @@ func Tx(c *gin.Context) {
 	txhash, err := relayTx(client, d, txRequest.TxBytes, chainName, txRequest.Owner)
 
 	if err != nil {
-		e := apierrors.New("tx", fmt.Errorf("relaying tx failed, %w", err), http.StatusBadRequest)
-
-		d.WriteError(c, e,
+		e := apierrors.New("tx", fmt.Errorf("relaying tx failed, %w", err), http.StatusBadRequest).WithLogContext(
 			"relaying tx failed",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -156,15 +152,14 @@ func GetTicket(c *gin.Context) {
 			"tx",
 			fmt.Errorf("cannot retrieve ticket with id %v", ticketId),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve ticket",
 			"name",
 			ticketId,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -190,13 +185,12 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 	err := c.BindJSON(&txRequest)
 	if err != nil {
-		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest)
-
-		d.WriteError(c, e,
+		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
 			"Failed to parse JSON",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -207,15 +201,14 @@ func GetTxFeeEstimate(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -226,15 +219,14 @@ func GetTxFeeEstimate(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -249,15 +241,14 @@ func GetTxFeeEstimate(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot estimate fees from sdk-service"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot estimate fees from sdk-service",
 			"name",
 			chainName,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/tx/api.go
+++ b/api/tx/api.go
@@ -41,7 +41,7 @@ func Tx(c *gin.Context) {
 	err := c.BindJSON(&txRequest)
 
 	if err != nil {
-		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
+		e := apierrors.New("tx", fmt.Sprintf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
 			"Failed to parse JSON",
 			"error",
 			err,
@@ -55,7 +55,7 @@ func Tx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve chain with name %v", chainName),
+			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -73,7 +73,7 @@ func Tx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -90,7 +90,7 @@ func Tx(c *gin.Context) {
 	txhash, err := relayTx(client, d, txRequest.TxBytes, chainName, txRequest.Owner)
 
 	if err != nil {
-		e := apierrors.New("tx", fmt.Errorf("relaying tx failed, %w", err), http.StatusBadRequest).WithLogContext(
+		e := apierrors.New("tx", fmt.Sprintf("relaying tx failed, %w", err), http.StatusBadRequest).WithLogContext(
 			"relaying tx failed",
 			"error",
 			err,
@@ -150,7 +150,7 @@ func GetTicket(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"tx",
-			fmt.Errorf("cannot retrieve ticket with id %v", ticketId),
+			fmt.Sprintf("cannot retrieve ticket with id %v", ticketId),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve ticket",
@@ -185,7 +185,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 
 	err := c.BindJSON(&txRequest)
 	if err != nil {
-		e := apierrors.New("tx", fmt.Errorf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
+		e := apierrors.New("tx", fmt.Sprintf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
 			"Failed to parse JSON",
 			"error",
 			err,
@@ -199,7 +199,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve chain with name %v", chainName),
+			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chain",
@@ -217,7 +217,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
 		).WithLogContext(
 			"cannot retrieve chain's sdk-service",
@@ -239,7 +239,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot estimate fees from sdk-service"),
+			fmt.Sprintf("cannot estimate fees from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot estimate fees from sdk-service",

--- a/api/tx/api.go
+++ b/api/tx/api.go
@@ -44,7 +44,7 @@ func Tx(c *gin.Context) {
 		e := apierrors.New("tx", fmt.Sprintf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
 			fmt.Errorf("Failed to parse JSON: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -60,7 +60,7 @@ func Tx(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -76,7 +76,7 @@ func Tx(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -84,10 +84,10 @@ func Tx(c *gin.Context) {
 	txhash, err := relayTx(client, d, txRequest.TxBytes, chainName, txRequest.Owner)
 
 	if err != nil {
-		e := apierrors.New("tx", fmt.Sprintf("relaying tx failed, %w", err), http.StatusBadRequest).WithLogContext(
+		e := apierrors.New("tx", fmt.Sprintf("relaying tx failed, %v", err), http.StatusBadRequest).WithLogContext(
 			fmt.Errorf("relaying tx failed: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -149,7 +149,7 @@ func GetTicket(c *gin.Context) {
 			"name",
 			ticketId,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -178,7 +178,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 		e := apierrors.New("tx", fmt.Sprintf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
 			fmt.Errorf("Failed to parse JSON: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -194,7 +194,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -210,7 +210,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -230,7 +230,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 			"name",
 			chainName,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/tx/api.go
+++ b/api/tx/api.go
@@ -42,9 +42,7 @@ func Tx(c *gin.Context) {
 
 	if err != nil {
 		e := apierrors.New("tx", fmt.Sprintf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
-			"Failed to parse JSON",
-			"error",
-			err,
+			fmt.Errorf("Failed to parse JSON: %w", err),
 		)
 		c.Error(e)
 
@@ -58,11 +56,9 @@ func Tx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -76,11 +72,9 @@ func Tx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -91,9 +85,7 @@ func Tx(c *gin.Context) {
 
 	if err != nil {
 		e := apierrors.New("tx", fmt.Sprintf("relaying tx failed, %w", err), http.StatusBadRequest).WithLogContext(
-			"relaying tx failed",
-			"error",
-			err,
+			fmt.Errorf("relaying tx failed: %w", err),
 		)
 		c.Error(e)
 
@@ -153,11 +145,9 @@ func GetTicket(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve ticket with id %v", ticketId),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve ticket",
+			fmt.Errorf("cannot retrieve ticket: %w", err),
 			"name",
 			ticketId,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -186,9 +176,7 @@ func GetTxFeeEstimate(c *gin.Context) {
 	err := c.BindJSON(&txRequest)
 	if err != nil {
 		e := apierrors.New("tx", fmt.Sprintf("failed to parse JSON"), http.StatusBadRequest).WithLogContext(
-			"Failed to parse JSON",
-			"error",
-			err,
+			fmt.Errorf("Failed to parse JSON: %w", err),
 		)
 		c.Error(e)
 
@@ -202,11 +190,9 @@ func GetTxFeeEstimate(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chain with name %v", chainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chain",
+			fmt.Errorf("cannot retrieve chain: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -220,11 +206,9 @@ func GetTxFeeEstimate(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with chain name %v", chain.CosmosSDKVersion, chain.ChainName),
 			http.StatusInternalServerError,
 		).WithLogContext(
-			"cannot retrieve chain's sdk-service",
+			fmt.Errorf("cannot retrieve chain's sdk-service: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -242,11 +226,9 @@ func GetTxFeeEstimate(c *gin.Context) {
 			fmt.Sprintf("cannot estimate fees from sdk-service"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot estimate fees from sdk-service",
+			fmt.Errorf("cannot estimate fees from sdk-service: %w", err),
 			"name",
 			chainName,
-			"error",
-			err,
 		)
 		c.Error(e)
 

--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -64,15 +64,14 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve srcChainInfo with name %v", srcChain),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve srcChainInfo",
 			"name",
 			srcChain,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -84,15 +83,14 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve srcChainInfo with name %v", destChain),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve srcChainInfo",
 			"name",
 			destChain,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -103,15 +101,14 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve sdk-service for version %s with srcChainInfo name %v", srcChainInfo.CosmosSDKVersion, srcChainInfo.ChainName),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve srcChainInfo's sdk-service",
 			"name",
 			srcChain,
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -126,9 +123,7 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve tx from sdk-service",
 			"txHash",
 			txHash,
@@ -137,6 +132,7 @@ func GetDestTx(c *gin.Context) {
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -152,9 +148,7 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("provided transaction is not ibc transfer"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"provided transaction is not ibc transfer",
 			"txHash",
 			txHash,
@@ -163,6 +157,7 @@ func GetDestTx(c *gin.Context) {
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -181,9 +176,7 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve destination tx",
 			"txHash",
 			txHash,
@@ -194,6 +187,7 @@ func GetDestTx(c *gin.Context) {
 			"status_code",
 			resp.Status,
 		)
+		c.Error(e)
 
 		return
 	}
@@ -205,9 +199,7 @@ func GetDestTx(c *gin.Context) {
 			"chains",
 			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve destination tx",
 			"txHash",
 			txHash,
@@ -216,6 +208,7 @@ func GetDestTx(c *gin.Context) {
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -65,11 +65,9 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve srcChainInfo with name %v", srcChain),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve srcChainInfo",
+			fmt.Errorf("cannot retrieve srcChainInfo: %w", err),
 			"name",
 			srcChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -84,11 +82,9 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve srcChainInfo with name %v", destChain),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve srcChainInfo",
+			fmt.Errorf("cannot retrieve srcChainInfo: %w", err),
 			"name",
 			destChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -102,11 +98,9 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve sdk-service for version %s with srcChainInfo name %v", srcChainInfo.CosmosSDKVersion, srcChainInfo.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve srcChainInfo's sdk-service",
+			fmt.Errorf("cannot retrieve srcChainInfo's sdk-service: %w", err),
 			"name",
 			srcChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -124,13 +118,11 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve tx from sdk-service",
+			fmt.Errorf("cannot retrieve tx from sdk-service: %w", err),
 			"txHash",
 			txHash,
 			"src srcChainInfo name",
 			srcChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -149,13 +141,11 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("provided transaction is not ibc transfer"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"provided transaction is not ibc transfer",
+			fmt.Errorf("provided transaction is not ibc transfer: %w", err),
 			"txHash",
 			txHash,
 			"src srcChainInfo name",
 			srcChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 
@@ -177,13 +167,11 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve destination tx",
+			fmt.Errorf("cannot retrieve destination tx: %w", err),
 			"txHash",
 			txHash,
 			"dest srcChainInfo name",
 			destChain,
-			"error",
-			err,
 			"status_code",
 			resp.Status,
 		)
@@ -200,13 +188,11 @@ func GetDestTx(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve destination tx",
+			fmt.Errorf("cannot retrieve destination tx: %w", err),
 			"txHash",
 			txHash,
 			"dest srcChainInfo name",
 			destChain,
-			"error",
-			err,
 		)
 		c.Error(e)
 

--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -62,7 +62,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve srcChainInfo with name %v", srcChain),
+			fmt.Sprintf("cannot retrieve srcChainInfo with name %v", srcChain),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve srcChainInfo",
@@ -81,7 +81,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve srcChainInfo with name %v", destChain),
+			fmt.Sprintf("cannot retrieve srcChainInfo with name %v", destChain),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve srcChainInfo",
@@ -99,7 +99,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve sdk-service for version %s with srcChainInfo name %v", srcChainInfo.CosmosSDKVersion, srcChainInfo.ChainName),
+			fmt.Sprintf("cannot retrieve sdk-service for version %s with srcChainInfo name %v", srcChainInfo.CosmosSDKVersion, srcChainInfo.ChainName),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve srcChainInfo's sdk-service",
@@ -121,7 +121,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve tx from sdk-service, %w", err),
+			fmt.Sprintf("cannot retrieve tx from sdk-service, %w", err),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve tx from sdk-service",
@@ -146,7 +146,7 @@ func GetDestTx(c *gin.Context) {
 	if len(r) == 0 {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("provided transaction is not ibc transfer"),
+			fmt.Sprintf("provided transaction is not ibc transfer"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"provided transaction is not ibc transfer",
@@ -174,7 +174,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil || resp.StatusCode != http.StatusOK {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
+			fmt.Sprintf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve destination tx",
@@ -197,7 +197,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Errorf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
+			fmt.Sprintf("cannot retrieve tx with packet sequence %s on %s", seqNum, destChain),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve destination tx",

--- a/api/tx/ibc.go
+++ b/api/tx/ibc.go
@@ -69,7 +69,7 @@ func GetDestTx(c *gin.Context) {
 			"name",
 			srcChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -86,7 +86,7 @@ func GetDestTx(c *gin.Context) {
 			"name",
 			destChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -102,7 +102,7 @@ func GetDestTx(c *gin.Context) {
 			"name",
 			srcChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -115,7 +115,7 @@ func GetDestTx(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"chains",
-			fmt.Sprintf("cannot retrieve tx from sdk-service, %w", err),
+			fmt.Sprintf("cannot retrieve tx from sdk-service, %v", err),
 			http.StatusBadRequest,
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve tx from sdk-service: %w", err),
@@ -124,7 +124,7 @@ func GetDestTx(c *gin.Context) {
 			"src srcChainInfo name",
 			srcChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -147,7 +147,7 @@ func GetDestTx(c *gin.Context) {
 			"src srcChainInfo name",
 			srcChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -175,7 +175,7 @@ func GetDestTx(c *gin.Context) {
 			"status_code",
 			resp.Status,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}
@@ -194,7 +194,7 @@ func GetDestTx(c *gin.Context) {
 			"dest srcChainInfo name",
 			destChain,
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/verifieddenoms/api.go
+++ b/api/verifieddenoms/api.go
@@ -32,7 +32,7 @@ func GetVerifiedDenoms(c *gin.Context) {
 	if err != nil {
 		e := apierrors.New(
 			"verified_denoms",
-			fmt.Errorf("cannot retrieve chains"),
+			fmt.Sprintf("cannot retrieve chains"),
 			http.StatusBadRequest,
 		).WithLogContext(
 			"cannot retrieve chains",

--- a/api/verifieddenoms/api.go
+++ b/api/verifieddenoms/api.go
@@ -37,7 +37,7 @@ func GetVerifiedDenoms(c *gin.Context) {
 		).WithLogContext(
 			fmt.Errorf("cannot retrieve chains: %w", err),
 		)
-		c.Error(e)
+		_ = c.Error(e)
 
 		return
 	}

--- a/api/verifieddenoms/api.go
+++ b/api/verifieddenoms/api.go
@@ -35,9 +35,7 @@ func GetVerifiedDenoms(c *gin.Context) {
 			fmt.Sprintf("cannot retrieve chains"),
 			http.StatusBadRequest,
 		).WithLogContext(
-			"cannot retrieve chains",
-			"error",
-			err,
+			fmt.Errorf("cannot retrieve chains: %w", err),
 		)
 		c.Error(e)
 

--- a/api/verifieddenoms/api.go
+++ b/api/verifieddenoms/api.go
@@ -34,13 +34,12 @@ func GetVerifiedDenoms(c *gin.Context) {
 			"verified_denoms",
 			fmt.Errorf("cannot retrieve chains"),
 			http.StatusBadRequest,
-		)
-
-		d.WriteError(c, e,
+		).WithLogContext(
 			"cannot retrieve chains",
 			"error",
 			err,
 		)
+		c.Error(e)
 
 		return
 	}

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -9,15 +9,19 @@ type Error struct {
 	StatusCode int
 	Cause      string
 
-	InternalCause    string
+	InternalCause    error
 	LogKeysAndValues []any
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Namespace, e.Cause)
+	return fmt.Sprintf("%s: %s: %v", e.Namespace, e.Cause, e.InternalCause)
 }
 
-func (e *Error) WithLogContext(internalCause string, keysAndValues ...any) *Error {
+func (e *Error) Unwrap() error {
+	return e.InternalCause
+}
+
+func (e *Error) WithLogContext(internalCause error, keysAndValues ...any) *Error {
 	e.InternalCause = internalCause
 	e.LogKeysAndValues = keysAndValues
 	return e

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -5,21 +5,16 @@ import (
 )
 
 type Error struct {
-	Namespace     string
-	StatusCode    int
-	LowLevelError error
-	Cause         string
+	Namespace  string
+	StatusCode int
+	Cause      string
 
 	InternalCause    string
 	LogKeysAndValues []any
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Namespace, e.LowLevelError.Error())
-}
-
-func (e *Error) Unwrap() error {
-	return e.LowLevelError
+	return fmt.Sprintf("%s: %s", e.Namespace, e.Cause)
 }
 
 func (e *Error) WithLogContext(internalCause string, keysAndValues ...any) *Error {
@@ -28,11 +23,10 @@ func (e *Error) WithLogContext(internalCause string, keysAndValues ...any) *Erro
 	return e
 }
 
-func New(namespace string, cause error, statusCode int) *Error {
+func New(namespace string, cause string, statusCode int) *Error {
 	return &Error{
-		StatusCode:    statusCode,
-		Namespace:     namespace,
-		LowLevelError: cause,
-		Cause:         cause.Error(),
+		StatusCode: statusCode,
+		Namespace:  namespace,
+		Cause:      cause,
 	}
 }

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -14,7 +14,12 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s: %v", e.Namespace, e.Cause, e.InternalCause)
+	c := e.Cause
+	if e.InternalCause != nil {
+		c = e.InternalCause.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", e.Namespace, c)
 }
 
 func (e *Error) Unwrap() error {

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -9,18 +9,20 @@ type Error struct {
 	StatusCode    int
 	LowLevelError error
 	Cause         string
+
+	logMsgAndArgs []any
 }
 
-func (e Error) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("%s: %s", e.Namespace, e.LowLevelError.Error())
 }
 
-func (e Error) Unwrap() error {
+func (e *Error) Unwrap() error {
 	return e.LowLevelError
 }
 
-func New(namespace string, cause error, statusCode int) Error {
-	return Error{
+func New(namespace string, cause error, statusCode int) *Error {
+	return &Error{
 		StatusCode:    statusCode,
 		Namespace:     namespace,
 		LowLevelError: cause,

--- a/lib/apierrors/error.go
+++ b/lib/apierrors/error.go
@@ -10,7 +10,8 @@ type Error struct {
 	LowLevelError error
 	Cause         string
 
-	logMsgAndArgs []any
+	InternalCause    string
+	LogKeysAndValues []any
 }
 
 func (e *Error) Error() string {
@@ -19,6 +20,12 @@ func (e *Error) Error() string {
 
 func (e *Error) Unwrap() error {
 	return e.LowLevelError
+}
+
+func (e *Error) WithLogContext(internalCause string, keysAndValues ...any) *Error {
+	e.InternalCause = internalCause
+	e.LogKeysAndValues = keysAndValues
+	return e
 }
 
 func New(namespace string, cause error, statusCode int) *Error {

--- a/lib/apierrors/user_error.go
+++ b/lib/apierrors/user_error.go
@@ -9,7 +9,7 @@ type UserFacingError struct {
 	Cause     string `json:"cause"`
 }
 
-func NewUserFacingError(id string, e Error) UserFacingError {
+func NewUserFacingError(id string, e *Error) UserFacingError {
 	return UserFacingError{
 		ID:        id,
 		Namespace: e.Namespace,


### PR DESCRIPTION
This PR continues my effort in reducing duplicate code, stop using `deps` just for the logger (and eventually we will be able to get rid of it completely).

Of course it's a quite big PR because there's a lot of duplication and I did a bunch of "search and replace", but 🤞 we are improving the situation little by little.