### PR TITLE
fix osmosis apr calculation

### DIFF
--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -1321,6 +1321,11 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 			return "", err
 		}
 
+		// only 25% of the newly minted tokens are distributed as staking rewards for osmosis
+		if strings.ToLower(chain.ChainName) == "osmosis" {
+			inflation = inflation.QuoInt64(4)
+		}
+
 		// calculate staking APR
 		apr := inflation.Quo(bondedTokens.Quo(supply)).MulInt64(100)
 		return apr.String(), nil

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -28,6 +28,7 @@ import (
 const (
 	aprCacheDuration = 24 * time.Hour
 	aprCachePrefix   = "api-server/chain-aprs"
+	osmosisChainName = "osmosis"
 )
 
 // GetChains returns the list of all the chains supported by demeris.
@@ -1322,7 +1323,7 @@ func getAPR(c *gin.Context) stringcache.HandlerFunc {
 		}
 
 		// only 25% of the newly minted tokens are distributed as staking rewards for osmosis
-		if strings.ToLower(chain.ChainName) == "osmosis" {
+		if strings.ToLower(chain.ChainName) == osmosisChainName {
 			inflation = inflation.QuoInt64(4)
 		}
 


### PR DESCRIPTION
https://medium.com/osmosis/osmo-token-distribution-ae27ea2bb4db
![image](https://user-images.githubusercontent.com/43192592/163102069-275f1832-a313-47fe-a12e-6a573a3c1c98.png)

According to this only 25% of minted tokens are distributed as staking rewards
. So the "apr inflation" would be 25% of the mint inflation
. If we divide the apr we got from [prod](https://api.emeris.com/v1/chain/osmosis/apr) (248.17) with 4 (25%)........we get 62.04 which is exactly the apr shown in keplr