### PR TITLE
feat: add aggregated /chains/status endpoint

### DIFF
--- a/api/chains/api.go
+++ b/api/chains/api.go
@@ -12,8 +12,10 @@ import (
 )
 
 func Register(router *gin.Engine, db *database.Database, s *store.Store, sdkServiceClients sdkservice.SDKServiceClients) {
-	router.GET("/chains", GetChains(db))
-	router.GET("/chains/fee/addresses", GetFeeAddresses(db))
+	router.Group("/chains").
+		GET("", GetChains(db)).
+		GET("/status", GetChainsStatuses(db)).
+		GET("/fee/addresses", GetFeeAddresses(db))
 
 	chain := router.Group("/chain/:chain")
 

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -1240,3 +1240,32 @@ func getAPR(c *gin.Context, sdkServiceClients sdkservice.SDKServiceClients) stri
 		return apr.String(), nil
 	}
 }
+
+// GetChainsStatuses returns the status of all the enabled chains.
+// @Summary Gets status for all enabled chains.
+// @Tags Chain
+// @ID statuses
+// @Description Gets status for all enabled chains.
+// @Produce json
+// @Success 200 {object} ChainsStatusesResponse
+// @Failure 500,403 {object} apierrors.UserFacingError
+// @Router /chains/status [get]
+func GetChainsStatuses(db *database.Database) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		res := NewChainsStatusesResponse()
+
+		statuses, err := db.ChainsOnlineStatuses()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, res)
+			return
+		}
+
+		for _, s := range statuses {
+			res.Chains[s.ChainName] = ChainStatus{
+				Online: s.Online,
+			}
+		}
+
+		c.JSON(http.StatusOK, res)
+	}
+}

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -1256,7 +1256,15 @@ func GetChainsStatuses(db *database.Database) gin.HandlerFunc {
 
 		statuses, err := db.ChainsOnlineStatuses()
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, res)
+			e := apierrors.New(
+				"chain",
+				"cannot retrieve online status for chains",
+				http.StatusInternalServerError,
+			).WithLogContext(
+				err,
+			)
+
+			_ = c.Error(e)
 			return
 		}
 

--- a/api/chains/chains.go
+++ b/api/chains/chains.go
@@ -1248,12 +1248,10 @@ func getAPR(c *gin.Context, sdkServiceClients sdkservice.SDKServiceClients) stri
 // @Description Gets status for all enabled chains.
 // @Produce json
 // @Success 200 {object} ChainsStatusesResponse
-// @Failure 500,403 {object} apierrors.UserFacingError
+// @Failure 500 {object} apierrors.UserFacingError
 // @Router /chains/status [get]
 func GetChainsStatuses(db *database.Database) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		res := NewChainsStatusesResponse()
-
 		statuses, err := db.ChainsOnlineStatuses()
 		if err != nil {
 			e := apierrors.New(
@@ -1268,6 +1266,7 @@ func GetChainsStatuses(db *database.Database) gin.HandlerFunc {
 			return
 		}
 
+		res := NewChainsStatusesResponse(len(statuses))
 		for _, s := range statuses {
 			res.Chains[s.ChainName] = ChainStatus{
 				Online: s.Online,

--- a/api/chains/chains_test.go
+++ b/api/chains/chains_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	chainEndpointUrl       = "http://%s/chain/%s"
 	chainsEndpointUrl      = "http://%s/chains"
+	chainsStatusesUrl      = "http://%s/chains/status"
 	chainStatusUrl         = "http://%s/chain/%s/status"
 	chainSupplyUrl         = "http://%s/chain/%s/supply"
 	verifyTraceEndpointUrl = "http://%s/chain/%s/denom/verify_trace/%s"
@@ -313,5 +314,49 @@ func TestGetChainSupply(t *testing.T) {
 			require.Equal(t, tt.expectedHttpCode, resp.StatusCode)
 		})
 	}
+	utils.TruncateCNSDB(testingCtx, t)
+}
+
+func TestGetChainsStatuses(t *testing.T) {
+	utils.RunTraceListnerMigrations(testingCtx, t)
+	utils.InsertTraceListnerData(testingCtx, t, verifyTraceData)
+
+	// arrange
+	testChains := []cns.Chain{
+		chainWithoutPublicEndpoints,
+		chainWithPublicEndpoints,
+		disabledChain,
+	}
+	for _, c := range testChains {
+		err := testingCtx.CnsDB.AddChain(c)
+		require.NoError(t, err)
+	}
+
+	// act
+	resp, err := http.Get(fmt.Sprintf(chainsStatusesUrl, testingCtx.Cfg.ListenAddr))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// assert
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	respStruct := chains.ChainsStatusesResponse{}
+	err = json.Unmarshal(body, &respStruct)
+	require.NoError(t, err)
+
+	expectedResult := chains.ChainsStatusesResponse{
+		Chains: map[string]chains.ChainStatus{
+			chainWithoutPublicEndpoints.ChainName: {
+				Online: false,
+			},
+			chainWithPublicEndpoints.ChainName: {
+				Online: true,
+			},
+		},
+	}
+	require.Equal(t, expectedResult, respStruct)
+	require.Equal(t, 200, resp.StatusCode)
+
 	utils.TruncateCNSDB(testingCtx, t)
 }

--- a/api/chains/models.go
+++ b/api/chains/models.go
@@ -179,8 +179,8 @@ type ChainsStatusesResponse struct {
 	Chains map[string]ChainStatus `json:"chains"`
 }
 
-func NewChainsStatusesResponse() ChainsStatusesResponse {
+func NewChainsStatusesResponse(sz int) ChainsStatusesResponse {
 	return ChainsStatusesResponse{
-		Chains: make(map[string]ChainStatus),
+		Chains: make(map[string]ChainStatus, sz),
 	}
 }

--- a/api/chains/models.go
+++ b/api/chains/models.go
@@ -170,3 +170,17 @@ type Pagination struct {
 type APRResponse struct {
 	APR float64 `json:"apr,omitempty"`
 }
+
+type ChainStatus struct {
+	Online bool `json:"online"`
+}
+
+type ChainsStatusesResponse struct {
+	Chains map[string]ChainStatus `json:"chains"`
+}
+
+func NewChainsStatusesResponse() ChainsStatusesResponse {
+	return ChainsStatusesResponse{
+		Chains: make(map[string]ChainStatus),
+	}
+}

--- a/api/database/chains.go
+++ b/api/database/chains.go
@@ -164,3 +164,27 @@ func (d *Database) PrimaryChannels(chainName string) ([]cns.ChannelQuery, error)
 		"chain_name": chainName,
 	})
 }
+
+type ChainOnlineStatusRow struct {
+	ChainName string `db:"chain_name"`
+	Online    bool   `db:"online"`
+}
+
+func (d *Database) ChainsOnlineStatuses() ([]ChainOnlineStatusRow, error) {
+	q := `
+	SELECT
+		c.chain_name,
+		parse_interval(c.valid_block_thresh) > current_timestamp() - b.block_time online
+	FROM cns.chains c
+	LEFT JOIN tracelistener.blocktime b
+	ON c.chain_name = b.chain_name
+	WHERE c.enabled;
+	`
+
+	var rows []ChainOnlineStatusRow
+	if err := d.dbi.DB.Select(&rows, q); err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}

--- a/api/database/chains.go
+++ b/api/database/chains.go
@@ -174,7 +174,10 @@ func (d *Database) ChainsOnlineStatuses() ([]ChainOnlineStatusRow, error) {
 	q := `
 	SELECT
 		c.chain_name,
-		parse_interval(c.valid_block_thresh) > current_timestamp() - b.block_time online
+		coalesce(
+			parse_interval(c.valid_block_thresh) > current_timestamp() - b.block_time,
+			false
+		) online
 	FROM cns.chains c
 	LEFT JOIN tracelistener.blocktime b
 	ON c.chain_name = b.chain_name


### PR DESCRIPTION
This PR adds `/chains/status` which aggregates all the `/chain/XXX/status` calls into one.

The list of the returned chains only contains **enabled** chains. This information can be used by the frontend to establish whether a chain is enabled or not.

Close #715.