### PR TITLE
build: prefix helm values so they can be set from shared scripts

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,13 +36,13 @@ spec:
             - name: DEMERIS-API_DEBUG
               value: "{{ .Values.debug }}"
             - name: DEMERIS-API_SENTRYDSN
-              value: "{{ .Values.sentryDSN }}"
+              value: "{{ .Values.apiServerSentryDSN }}"
             - name: DEMERIS-API_SENTRYENVIRONMENT
-              value: "{{ .Values.sentryEnvironment }}"
+              value: "{{ .Values.apiServerSentryEnvironment }}"
             - name: DEMERIS-API_SENTRYSAMPLERATE
-              value: "{{ .Values.sentrySampleRate }}"
+              value: "{{ .Values.apiServerSentrySampleRate }}"
             - name: DEMERIS-API_SENTRYTRACESSAMPLERATE
-              value: "{{ .Values.sentryTracesSampleRate }}"
+              value: "{{ .Values.apiServerSentryTracesSampleRate }}"
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       terminationGracePeriodSeconds: 10

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,7 +31,7 @@ hpaMaxReplicas: 5
 hpaAverageMemoryUtilization: 90
 
 # no value means sentry is disabled
-sentryDSN:
-sentryEnvironment: local
-sentrySampleRate: 1.0
-sentryTracesSampleRate: 0.3
+apiServerSentryDSN:
+apiServerSentryEnvironment: local
+apiServerSentrySampleRate: 1.0
+apiServerSentryTracesSampleRate: 0.3


### PR DESCRIPTION
It's great that we have a single github action or scripts that can deploy virtually any helm chart: https://github.com/EmerisHQ/demeris-backend/blob/master/.github/workflows/deploy-image-on-dev.yml, https://github.com/EmerisHQ/demeris-backend/blob/master/.github/workflows/deploy-image.yml.

But unfortunately we cannot share the same key for helm values (unless we want to complicate the logic in the github action very much). Maybe we will find better ways for passing this params in the future but for now I think it's fairly easy to just use a prefix 😁 