### PR TITLE
ci: run docker-build action on new releases

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,9 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types:
+      - released
 
 jobs:
   api-server:


### PR DESCRIPTION
It should now run automatically when we merge new changes.